### PR TITLE
Support loading z/OSMF connection details from profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Zowe Python Client SDK 
+# Zowe Python Client SDK
 
 ![](https://img.shields.io/badge/license-EPL--2.0-blue) ![](https://img.shields.io/badge/version-0.1.0-yellow)
 
-The Zowe Python Client SDK is an open-source Python package for z/OSMF REST API. It allows you to leverage mainframe capabilities from your python programs with minimum effort.
+The Zowe Python Client SDK is an open-source Python package for z/OSMF REST API. It allows you to leverage mainframe capabilities from your Python programs with minimum effort.
 
 ![](./img/zeepy.gif)
 
@@ -12,7 +12,7 @@ This package uses `requests-2.22`
 
 # Quick start
 
-Start by importing the Zeepy class and create a object that will be the handler for all z/OSMF requests:
+Start by importing the Zeepy class and create an object that will be the handler for all z/OSMF requests:
 
 ```python
 from zeepy import Zeepy
@@ -22,7 +22,7 @@ z = Zeepy(zosmf_host='<host address>', zosmf_user='<zosmf user>', zosmf_password
 
 # Available options
 
-Currently Zeepy support's the following interfaces:
+Currently Zeepy supports the following interfaces:
 
 * Console commands
 * z/OSMF Information retrival
@@ -103,7 +103,7 @@ If you don't provide any session parameter Zeepy will attempt to start a session
 To end a TSO address space
 ```python
 z.tso.end_tso_session("<session-key>")
-``` 
+```
 
 In order to issue a TSO command
 ```python
@@ -118,7 +118,7 @@ result = z.zosmf.get_info()
 The result will be a JSON object containing z/OSMF information
 
 
-# Acknowledgments 
+# Acknowledgments
 
-* Make sure to check out the [Zowe project](https://github.com/zowe)! 
+* Make sure to check out the [Zowe project](https://github.com/zowe)!
 * For further information on z/OSMF REST API, click [HERE](https://www.ibm.com/support/knowledgecenter/SSLTBW_2.1.0/com.ibm.zos.v2r1.izua700/IZUHPINFO_RESTServices.htm)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+keyring
+pyyaml
+requests>=2.22

--- a/zeepy/utilities/__init__.py
+++ b/zeepy/utilities/__init__.py
@@ -1,7 +1,11 @@
-from .zosmf_connection import ZosmfConnection
 from .api import ZosmfApi
-from .request_handler import RequestHandler
 from .constants import constants
-from .exceptions import InvalidRequestMethod
-from .exceptions import RequestFailed
-from .exceptions import UnexpectedStatus
+from .exceptions import (
+    InvalidRequestMethod,
+    MissingConnectionArgs,
+    RequestFailed,
+    UnexpectedStatus,
+)
+from .request_handler import RequestHandler
+from .zosmf_connection import ZosmfConnection
+from .zosmf_profile import ZosmfProfile

--- a/zeepy/utilities/constants.py
+++ b/zeepy/utilities/constants.py
@@ -9,4 +9,8 @@ SPDX-License-Identifier: EPL-2.0
 Copyright Contributors to the Zeepy project.
 """
 
-constants = {"TsoSessionNotFound": "IZUG1126E"}
+constants = {
+    "SecureValuePrefix": "managed by ",
+    "TsoSessionNotFound": "IZUG1126E",
+    "ZoweCredentialKey": "Zowe-Plugin",
+}

--- a/zeepy/utilities/exceptions.py
+++ b/zeepy/utilities/exceptions.py
@@ -35,8 +35,20 @@ class RequestFailed(Exception):
 
 class FileNotFound(Exception):
     def __init__(self, input_path):
-        super()._init__(
-            "The path {} provided is not a file.".format(
-                input_path
-            )
+        super()._init__("The path {} provided is not a file.".format(input_path))
+
+
+class MissingConnectionArgs(Exception):
+    def __init__(self):
+        super().__init__(
+            "You must provide host, user, and password for a z/OSMF "
+            "connection, or the name of a z/OSMF profile that exists on your "
+            "system."
+        )
+
+
+class SecureProfileLoadFailed(Exception):
+    def __init__(self, profile_name, error_msg):
+        super().__init__(
+            "Failed to load secure profile {}: {}".format(profile_name, error_msg)
         )

--- a/zeepy/utilities/zosmf_profile.py
+++ b/zeepy/utilities/zosmf_profile.py
@@ -1,0 +1,96 @@
+"""
+This program and the accompanying materials are made available under the terms of the
+Eclipse Public License v2.0 which accompanies this distribution, and is available at
+
+https://www.eclipse.org/legal/epl-v20.html
+
+SPDX-License-Identifier: EPL-2.0
+
+Copyright Contributors to the Zeepy project.
+"""
+
+import base64
+import os.path
+import sys
+import yaml
+
+from .constants import constants
+from .exceptions import SecureProfileLoadFailed
+from .zosmf_connection import ZosmfConnection
+
+HAS_KEYRING = True
+try:
+    import keyring
+except ImportError:
+    HAS_KEYRING = False
+
+
+class ZosmfProfile:
+    def __init__(self, profile_name):
+        """Base class for z/OSMF profile"""
+        self.profile_name = profile_name
+
+    @property
+    def profiles_dir(self):
+        home_dir = os.path.expanduser("~")
+        return os.path.join(home_dir, ".zowe", "profiles", "zosmf")
+
+    def load(self):
+        """Load z/OSMF connection details from a z/OSMF profile"""
+        profile_file = os.path.join(
+            self.profiles_dir, "{}.yaml".format(self.profile_name)
+        )
+
+        with open(profile_file, "r") as fileobj:
+            profile_yaml = yaml.safe_load(fileobj)
+
+        zosmf_host = profile_yaml["host"]
+        if "port" in profile_yaml:
+            zosmf_host += ":{}".format(profile_yaml["port"])
+
+        zosmf_user = profile_yaml["user"]
+        zosmf_password = profile_yaml["password"]
+        if zosmf_user.startswith(
+            constants["SecureValuePrefix"]
+        ) and zosmf_password.startswith(constants["SecureValuePrefix"]):
+            zosmf_user, zosmf_password = self.__load_secure_credentials()
+
+        zosmf_ssl_verification = True
+        if "rejectUnauthorized" in profile_yaml:
+            zosmf_ssl_verification = not profile_yaml["rejectUnauthorized"]
+
+        return ZosmfConnection(
+            zosmf_host, zosmf_user, zosmf_password, zosmf_ssl_verification
+        )
+
+    def __get_secure_value(self, name):
+        service_name = constants["ZoweCredentialKey"]
+        account_name = "zosmf_{}_{}".format(self.profile_name, name)
+        secret_value = keyring.get_password(
+            service_name + "/" + account_name, account_name
+        )
+
+        if sys.platform == "win32":
+            secret_value = secret_value.encode("utf-16")
+
+        secret_value = base64.b64decode(secret_value).decode()
+
+        if sys.platform == "win32":
+            secret_value = secret_value.strip('"')
+
+        return secret_value
+
+    def __load_secure_credentials(self):
+        """Load secure credentials for a z/OSMF profile"""
+        if not HAS_KEYRING:
+            raise SecureProfileLoadFailed(
+                self.profile_name, "Keyring module not installed"
+            )
+
+        try:
+            zosmf_user = self.__get_secure_value("user")
+            zosmf_password = self.__get_secure_value("password")
+        except Exception as e:
+            raise SecureProfileLoadFailed(self.profile_name, e)
+        else:
+            return (zosmf_user, zosmf_password)

--- a/zeepy/zeepy.py
+++ b/zeepy/zeepy.py
@@ -9,26 +9,38 @@ SPDX-License-Identifier: EPL-2.0
 Copyright Contributors to the Zeepy project.
 """
 
-from .utilities import ZosmfConnection
 from .console import Console
-from .zosmf import Zosmf
+from .files import Files
 from .jobs import Jobs
 from .tso import Tso
-from .files import Files
+from .utilities import MissingConnectionArgs, ZosmfConnection, ZosmfProfile
+from .zosmf import Zosmf
 
 
 class Zeepy:
     """Main class for Zeepy"""
+
     def __init__(
         self,
-        zosmf_host,
-        zosmf_user,
-        zosmf_password,
-        ssl_verification=True
+        zosmf_host=None,
+        zosmf_user=None,
+        zosmf_password=None,
+        ssl_verification=True,
+        zosmf_profile=None,
     ):
-        self.connection = ZosmfConnection(
-            zosmf_host, zosmf_user, zosmf_password, ssl_verification
-        )
+        if zosmf_profile:
+            self.connection = ZosmfProfile(zosmf_profile).load()
+        else:
+            if not zosmf_host or not zosmf_user or not zosmf_password:
+                raise MissingConnectionArgs()
+
+            self.connection = ZosmfConnection(
+                zosmf_host=zosmf_host,
+                zosmf_user=zosmf_user,
+                zosmf_password=zosmf_password,
+                ssl_verification=ssl_verification,
+            )
+
         self.console = Console(self.connection)
         self.zosmf = Zosmf(self.connection)
         self.jobs = Jobs(self.connection)


### PR DESCRIPTION
This makes it possible to instantiate the Zeepy class using a z/OSMF profile created in Zowe CLI or Zowe Explorer, rather than needing hardcoded connection details.

Both plain text and secure profiles are supported on Windows. On Linux only plain text profiles are supported because of [this issue](https://github.com/jaraco/keyring/issues/402).