### PR TITLE
Enable loading secure credentials on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ from zowe_sdk import ZoweSDK
 z = ZoweSDK(zosmf_profile='<profile name>')
 ```
 
-**Important**: If your z/OSMF profile uses a credentials manager, this approach will only work on a Windows workstation due to [this](https://github.com/jaraco/keyring/issues/402) issue.
+**Important**: If your z/OSMF profile uses a credentials manager, this approach may not work depending on your operating system. Support for loading secure profiles has only been tested on Windows and Ubuntu so far.
 
 
 # Available options


### PR DESCRIPTION
Works around [this issue](https://github.com/jaraco/keyring/issues/402) by looking for "account" instead of "username" field (to be compatible with how Keytar and Zowe SCS store credentials).

Given that there seem to be some platform-specific oddities around how credentials are stored, updated the disclaimer in the README stating that secure credential support has only been tested in Windows and Ubuntu. It has not yet been tested on macOS or other Linux distros.