### PR TITLE
Added method to create a USS file in Files Class

### DIFF
--- a/src/zos_files/zowe/zos_files_for_zowe_sdk/files.py
+++ b/src/zos_files/zowe/zos_files_for_zowe_sdk/files.py
@@ -77,6 +77,27 @@ class Files(SdkApi):
         custom_args["url"] = "{}ds/{}".format(self.request_endpoint, dataset_name)
         response_json = self.request_handler.perform_request("GET", custom_args)
         return response_json
+    
+    def create_uss_file(self, file_path, type, mode = 'rwxr-xr-x'):
+        """
+        Add a file or directory
+        Parameters
+        ----------
+        file_name of the file to add
+        type = "file"
+        mode Ex:- rwxr-xr-x
+
+        """
+
+        data = {
+            "type": type,
+            "mode": mode
+        }
+        custom_args = self.create_custom_request_arguments()
+        custom_args["params"] = data
+        custom_args["url"] = "{}fs/{}".format(self.request_endpoint, file_path.lstrip("/"))
+        response_json = self.request_handler.perform_request("DELETE", custom_args, expected_code=201)
+        return response_json
 
     def write_to_dsn(self, dataset_name, data):
         """Write content to an existing dataset.

--- a/src/zos_files/zowe/zos_files_for_zowe_sdk/files.py
+++ b/src/zos_files/zowe/zos_files_for_zowe_sdk/files.py
@@ -93,7 +93,6 @@ class Files(SdkApi):
             "type": type,
             "mode": mode
         }
-        
         custom_args = self.create_custom_request_arguments()
         custom_args["params"] = data
         custom_args["url"] = "{}fs/{}".format(self.request_endpoint, file_path.lstrip("/"))

--- a/src/zos_files/zowe/zos_files_for_zowe_sdk/files.py
+++ b/src/zos_files/zowe/zos_files_for_zowe_sdk/files.py
@@ -93,6 +93,7 @@ class Files(SdkApi):
             "type": type,
             "mode": mode
         }
+        
         custom_args = self.create_custom_request_arguments()
         custom_args["params"] = data
         custom_args["url"] = "{}fs/{}".format(self.request_endpoint, file_path.lstrip("/"))


### PR DESCRIPTION
Added a `create_uss_file` method to add a Unix file or directory by POSTing to the endpoint `/zosmf/restfiles/fs/<filePath>` as documented [Here](https://www.ibm.com/docs/en/zos/2.4.0?topic=interface-create-unix-file-directory#CreateUnixFile)
Resolves #42 