### PR TITLE
Only publish dev releases for labelled PRs

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -1,19 +1,21 @@
 name: Zowe SDK Release
 
 on:
-  push:
+  pull_request_target:
+    types:
+      - closed
     branches:
       - next
-    paths:
-      - 'src/**'
 
 jobs:
   release:
+    if: ${{ github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release-dev') }}
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
       with:
+        ref: next
         token: ${{ secrets.ZOWE_ROBOT_TOKEN }}
 
     - name: Set up Python 3.7


### PR DESCRIPTION
Initially I set up the Release workflow to run on all pushes to the "next" branch that modify the "src" folder. The creation of a new GitHub release every time a PR is merged into the "next" branch may be undesirable. I do not want to spam our release history 🙂 

In this PR, the behavior is changed to only publish dev releases for PRs merged into the "next" branch with the "release-dev" label.

