### PR TITLE
Refactored Profile Manager Class

### DIFF
--- a/src/core/zowe/core_for_zowe_sdk/__init__.py
+++ b/src/core/zowe/core_for_zowe_sdk/__init__.py
@@ -11,3 +11,4 @@ from .sdk_api import SdkApi
 from .session_constants import *
 from .session import Session
 from .zosmf_profile import ZosmfProfile
+from .config_file import ConfigFile

--- a/src/core/zowe/core_for_zowe_sdk/config_file.py
+++ b/src/core/zowe/core_for_zowe_sdk/config_file.py
@@ -125,12 +125,16 @@ class ConfigFile:
         profile_name: Optional[str] = None,
         profile_type: Optional[str] = None,
     ) -> Tuple[dict, str]:
+        """
+        Load given profile with values populated from base profile
+        """
         if self.profiles is None:
             self.init_from_file()
 
         if profile_name is None and profile_type is None:
             raise ProfileNotFound(
-                "Could not find profile as both profile_name and profile_type is not set."
+                profile_name=profile_name,
+                error_msg="Could not find profile as both profile_name and profile_type is not set.",
             )
 
         if profile_name is None:
@@ -194,7 +198,7 @@ class ConfigFile:
             profilename = self.defaults[profile_type]
         except KeyError:
             warnings.warn(
-                "Given profile type has no default profilename",
+                f"Given profile type '{profile_type}' has no default profilename",
                 ProfileParsingWarning,
             )
         else:
@@ -208,14 +212,14 @@ class ConfigFile:
                     return key
             except KeyError:
                 warnings.warn(
-                    f"Profile {key} has no type attribute",
+                    f"Profile '{key}' has no type attribute",
                     ProfileParsingWarning,
                 )
 
         # if no profile with matching type found, we raise an exception
         raise ProfileNotFound(
             profile_name=profile_type,
-            error_msg=f"No profile with matching profile_type {profile_type} found",
+            error_msg=f"No profile with matching profile_type '{profile_type}' found",
         )
 
     def load_profile_properties(self, profile_name: str) -> dict:
@@ -226,7 +230,7 @@ class ConfigFile:
         try:
             props = self.profiles[profile_name]["properties"]
         except Exception as exc:
-            raise ProfileNotFound("Profile {profile_name} not found", error_msg=exc)
+            raise ProfileNotFound("Profile {profile_name} not found", error_msg=exc) from exc
 
         secure_fields: list = self.profiles[profile_name].get("secure", [])
 
@@ -293,7 +297,7 @@ class ConfigFile:
                 raise SecureProfileLoadFailed(
                     constants["ZoweServiceName"],
                     error_msg="No credentials found for loaded config file as well as for global config",
-                )
+                ) from exc
             else:
                 warnings.warn(
                     f"Credentials not found for given config, using global credentials {GLOBAL_CONFIG_PATH}",

--- a/src/core/zowe/core_for_zowe_sdk/config_file.py
+++ b/src/core/zowe/core_for_zowe_sdk/config_file.py
@@ -16,7 +16,7 @@ import re
 import sys
 import warnings
 from dataclasses import dataclass
-from typing import Tuple, Union
+from typing import Tuple, Optional
 
 import commentjson
 
@@ -68,10 +68,10 @@ class ConfigFile:
 
     type: str
     name: str
-    _location: Union[str, None] = None
-    profiles: Union[dict, None] = None
-    defaults: Union[dict, None] = None
-    secure_props: Union[dict, None] = None
+    _location: Optional[str] = None
+    profiles: Optional[dict] = None
+    defaults: Optional[dict] = None
+    secure_props: Optional[dict] = None
 
     @property
     def filename(self) -> str:
@@ -84,14 +84,14 @@ class ConfigFile:
         return self.name
 
     @property
-    def filepath(self) -> Union[str, None]:
+    def filepath(self) -> Optional[str]:
         if not self.location:
             return None
 
         return os.path.join(self.location, self.filename)
 
     @property
-    def location(self) -> Union[str, None]:
+    def location(self) -> Optional[str]:
         return self._location
 
     @location.setter
@@ -122,8 +122,8 @@ class ConfigFile:
 
     def get_profile(
         self,
-        profile_name: Union[str, None] = None,
-        profile_type: Union[str, None] = None,
+        profile_name: Optional[str] = None,
+        profile_type: Optional[str] = None,
     ) -> Tuple[dict, str]:
         if self.profiles is None:
             self.init_from_file()

--- a/src/core/zowe/core_for_zowe_sdk/config_file.py
+++ b/src/core/zowe/core_for_zowe_sdk/config_file.py
@@ -154,20 +154,6 @@ class ConfigFile:
 
         props: dict = self.load_profile_properties(profile_name=profile_name)
 
-        try:
-            base_profile = self.get_profilename_from_profiletype(
-                profile_type=BASE_PROFILE
-            )
-        except ProfileNotFound:
-            if self.type == TEAM_CONFIG:
-                warnings.warn(
-                    f"Base profile not found in {self.filepath}",
-                    ProfileNotFoundWarning,
-                )
-        else:
-            base_props = self.load_profile_properties(profile_name=base_profile)
-            props.update(base_props)
-
         return Profile(props, profile_name, self._secure_props_not_found)
 
     def autodiscover_config_dir(self):

--- a/src/core/zowe/core_for_zowe_sdk/config_file.py
+++ b/src/core/zowe/core_for_zowe_sdk/config_file.py
@@ -15,21 +15,24 @@ import os.path
 import re
 import sys
 import warnings
-
 from dataclasses import dataclass
 from typing import Tuple, Union
 
 import commentjson
 
+from .constants import constants
 from .custom_warnings import (
     ProfileNotFoundWarning,
     ProfileParsingWarning,
     SecurePropsNotFoundWarning,
 )
-
-from .constants import constants
-from .exceptions import ProfileNotFound, SecureValuesNotFound, SecureProfileLoadFailed
-from .profile_constants import GLOBAL_CONFIG_NAME, TEAM_CONFIG, USER_CONFIG
+from .exceptions import ProfileNotFound, SecureProfileLoadFailed, SecureValuesNotFound
+from .profile_constants import (
+    BASE_PROFILE,
+    GLOBAL_CONFIG_NAME,
+    TEAM_CONFIG,
+    USER_CONFIG,
+)
 
 HAS_KEYRING = True
 try:
@@ -138,7 +141,9 @@ class ConfigFile:
         props: dict = self.load_profile_properties(profile_name=profile_name)
 
         try:
-            base_profile = self.get_profilename_from_profiletype(profile_type="base")
+            base_profile = self.get_profilename_from_profiletype(
+                profile_type=BASE_PROFILE
+            )
         except ProfileNotFound:
             if self.type == TEAM_CONFIG:
                 warnings.warn(

--- a/src/core/zowe/core_for_zowe_sdk/config_file.py
+++ b/src/core/zowe/core_for_zowe_sdk/config_file.py
@@ -1,0 +1,282 @@
+"""Zowe Python Client SDK.
+
+This program and the accompanying materials are made available under the terms of the
+Eclipse Public License v2.0 which accompanies this distribution, and is available at
+
+https://www.eclipse.org/legal/epl-v20.html
+
+SPDX-License-Identifier: EPL-2.0
+
+Copyright Contributors to the Zowe Project.
+"""
+
+import base64
+import os.path
+import re
+import sys
+import warnings
+
+from dataclasses import dataclass
+from typing import Tuple, Union
+
+import commentjson
+
+from .custom_warnings import (
+    ProfileNotFoundWarning,
+    ProfileParsingWarning,
+    SecurePropsNotFoundWarning,
+)
+
+from .constants import constants
+from .exceptions import ProfileNotFound, SecureValuesNotFound, SecureProfileLoadFailed
+from .profile_constants import GLOBAL_CONFIG_NAME, TEAM_CONFIG, USER_CONFIG
+
+HAS_KEYRING = True
+try:
+    import keyring
+except ImportError:
+    HAS_KEYRING = False
+
+HOME = os.path.expanduser("~")
+GLOBAl_CONFIG_LOCATION = os.path.join(HOME, ".zowe")
+GLOBAL_CONFIG_PATH = os.path.join(
+    GLOBAl_CONFIG_LOCATION, f"{GLOBAL_CONFIG_NAME}.config.json"
+)
+CURRENT_DIR = os.getcwd()
+
+
+@dataclass
+class ConfigFile:
+    """
+    Class used to represent a single config file.
+
+    Mainly it will have the following details :
+    1. Type ("User Config" or "Team Config")
+        User Configs override Team Configs.
+        User Configs are used to have personalised config details
+        that the user don't want to have in the Team Config.
+    2. Directory in which the file is located.
+    3. Name (excluding .config.json or .config.user.json)
+    4. Contents of the file.
+    4.1 Profiles
+    4.2 Defaults
+    5. Secure Properties associated with the file.
+    """
+
+    type: str
+    name: str
+    _location: Union[str, None] = None
+    profiles: Union[dict, None] = None
+    defaults: Union[dict, None] = None
+    secure_props: Union[dict, None] = None
+
+    @property
+    def filename(self) -> str:
+        if self.type == TEAM_CONFIG:
+            return f"{self.name}.config.json"
+
+        if self.type == USER_CONFIG:
+            return f"{self.name}.config.user.json"
+
+        return self.name
+
+    @property
+    def filepath(self) -> Union[str, None]:
+        if not self.location:
+            return None
+
+        return os.path.join(self.location, self.filename)
+
+    @property
+    def location(self) -> Union[str, None]:
+        return self._location
+
+    @location.setter
+    def location(self, dirname: str) -> None:
+        if os.path.isdir(dirname):
+            self._location = dirname
+        else:
+            raise FileNotFoundError(f"given path {dirname} is not valid")
+
+    def init_from_file(self) -> None:
+        if self.filepath is None:
+            self.autodiscover_config_dir()
+
+        with open(self.filepath, encoding="UTF-8", mode="r") as fileobj:
+            profile_jsonc = commentjson.load(fileobj)
+
+        self.profiles = profile_jsonc["profiles"]
+        self.defaults = profile_jsonc["defaults"]
+
+        self.load_secure_props()
+
+    def get_profile(
+        self,
+        profile_name: Union[str, None] = None,
+        profile_type: Union[str, None] = None,
+    ) -> Tuple[dict, str]:
+        if self.profiles is None:
+            self.init_from_file()
+
+        if profile_name is None and profile_type is None:
+            raise ProfileNotFound(
+                "Could not find profile as both profile_name and profile_type is not set."
+            )
+
+        if profile_name is None:
+            profile_name = self.get_profilename_from_profiletype(
+                profile_type=profile_type
+            )
+
+        props: dict = self.load_profile_properties(profile_name=profile_name)
+
+        try:
+            base_profile = self.get_profilename_from_profiletype(profile_type="base")
+        except ProfileNotFound:
+            if self.type == TEAM_CONFIG:
+                warnings.warn(
+                    f"Base profile not found in {self.filepath}",
+                    ProfileNotFoundWarning,
+                )
+        else:
+            base_props = self.load_profile_properties(profile_name=base_profile)
+            props.update(base_props)
+
+        return props, profile_name
+
+    def autodiscover_config_dir(self):
+        """
+        Autodiscover Zowe z/OSMF Team Config files by going up the path from
+        current working directory
+
+        Return path if it finds the config directory,
+        Else, it returns None
+        """
+
+        current_dir = CURRENT_DIR
+
+        while True:
+            path = os.path.join(current_dir, self.filename)
+
+            if os.path.isfile(path):
+                self.location = current_dir
+                return
+
+            # check if have arrived at the root directory
+            if current_dir == os.path.dirname(current_dir):
+                break
+
+            current_dir = os.path.dirname(current_dir)
+
+        raise FileNotFoundError(f"Could not find the file {self.filename}")
+
+    def get_profilename_from_profiletype(self, profile_type: str) -> str:
+        """
+        Return exact profilename of the profile to load from the mentioned type
+
+        First tries to look into the defaults, if not found,
+        then it tries to iterate through the profiles
+        """
+        # try to get the profilename from defaults
+        try:
+            profilename = self.defaults[profile_type]
+        except KeyError:
+            warnings.warn(
+                "Given profile type has no default profilename",
+                ProfileParsingWarning,
+            )
+        else:
+            return profilename
+
+        # iterate through the profiles and check if profile is found
+        for (key, value) in self.profiles.items():
+            try:
+                temp_profile_type = value["type"]
+                if profile_type == temp_profile_type:
+                    return key
+            except KeyError:
+                warnings.warn(
+                    f"Profile {key} has no type attribute",
+                    ProfileParsingWarning,
+                )
+
+        # if no profile with matching type found, we raise an exception
+        raise ProfileNotFound(
+            profile_name=profile_type,
+            error_msg=f"No profile with matching profile_type {profile_type} found",
+        )
+
+    def load_profile_properties(self, profile_name: str) -> dict:
+        """
+        Load exact profile properties (without prepopulated fields from base profile)
+        from the profile dict and populate fields from the secure credentials storage
+        """
+        try:
+            props = self.profiles[profile_name]["properties"]
+        except Exception as exc:
+            raise ProfileNotFound("Profile {profile_name} not found", error_msg=exc)
+
+        secure_fields: list = self.profiles[profile_name].get("secure", [])
+
+        # load properties with key as profile.{profile_name}.properties.{*}
+        for (key, value) in self.secure_props.items():
+            if re.match("profiles\\." + profile_name + "\\.properties\\.[a-z]+", key):
+                property_name = key.split(".")[3]
+                if property_name in secure_fields:
+                    props[property_name] = value
+                    secure_fields.remove(property_name)
+
+        if len(secure_fields) > 0:
+            raise SecureValuesNotFound(secure_fields)
+
+        return props
+
+    def load_secure_props(self) -> None:
+        """
+        load secure_props stored for the given config
+
+        if keyring is not initialized, set empty value
+        """
+        if not HAS_KEYRING:
+            self.secure_props = {}
+
+        try:
+            service_name = constants["ZoweServiceName"]
+
+            if sys.platform == "win32":
+                service_name += "/" + constants["ZoweAccountName"]
+
+            secret_value = keyring.get_password(
+                service_name, constants["ZoweAccountName"]
+            )
+
+        except Exception as exc:
+            raise SecureProfileLoadFailed(
+                constants["ZoweServiceName"], error_msg=str(exc)
+            ) from exc
+
+        secure_config: str
+        if sys.platform == "win32":
+            secure_config = secret_value.encode("utf-16")
+        else:
+            secure_config = secret_value
+
+        secure_config_json = commentjson.loads(base64.b64decode(secure_config).decode())
+
+        # first look for credentials stored for currently loaded config
+        # then look for default credential stored for user_directory/.zowe/zowe.config.json
+        try:
+            self.secure_props = secure_config_json[self.location]
+        except KeyError:
+            try:
+                self.secure_props = secure_config_json[GLOBAL_CONFIG_PATH]
+            except KeyError as exc:
+                raise SecureProfileLoadFailed(
+                    constants["ZoweServiceName"],
+                    error_msg="No credentials found for loaded config file as well as for global config",
+                )
+            else:
+                warnings.warn(
+                    f"Credentials not found for given config, using global credentials {GLOBAL_CONFIG_PATH}",
+                    SecurePropsNotFoundWarning,
+                )

--- a/src/core/zowe/core_for_zowe_sdk/config_file.py
+++ b/src/core/zowe/core_for_zowe_sdk/config_file.py
@@ -109,8 +109,8 @@ class ConfigFile:
         with open(self.filepath, encoding="UTF-8", mode="r") as fileobj:
             profile_jsonc = commentjson.load(fileobj)
 
-        self.profiles = profile_jsonc["profiles"]
-        self.defaults = profile_jsonc["defaults"]
+        self.profiles = profile_jsonc.get("profiles", {})
+        self.defaults = profile_jsonc.get("defaults", {})
 
         # loading secure props is done in load_profile_properties
         # since we want to try loading secure properties only when

--- a/src/core/zowe/core_for_zowe_sdk/config_file.py
+++ b/src/core/zowe/core_for_zowe_sdk/config_file.py
@@ -241,7 +241,7 @@ class ConfigFile:
             props = self.profiles[profile_name]["properties"]
         except Exception as exc:
             raise ProfileNotFound(
-                "Profile {profile_name} not found", error_msg=exc
+                f"Profile {profile_name} not found", error_msg=exc
             ) from exc
 
         secure_fields: list = self.profiles[profile_name].get("secure", [])
@@ -301,23 +301,13 @@ class ConfigFile:
 
         secure_config_json = commentjson.loads(base64.b64decode(secure_config).decode())
 
-        # first look for credentials stored for currently loaded config
-        # then look for default credential stored for user_directory/.zowe/zowe.config.json
+        # look for credentials stored for currently loaded config
         try:
-            self.secure_props = secure_config_json[self.location]
-        except KeyError:
-            try:
-                self.secure_props = secure_config_json[GLOBAL_CONFIG_PATH]
-            except KeyError as exc:
-                error_msg = str(exc)
-                warnings.warn(
-                    f"No credentials found for loaded config file '{self.filepath}'"
-                    f" as well as for global config '{GLOBAL_CONFIG_PATH}'"
-                    f" with error '{error_msg}'",
-                    SecurePropsNotFoundWarning,
-                )
-            else:
-                warnings.warn(
-                    f"Credentials not found for given config, using global credentials {GLOBAL_CONFIG_PATH}",
-                    SecurePropsNotFoundWarning,
-                )
+            self.secure_props = secure_config_json.get(self.filepath, {})
+        except KeyError as exc:
+            error_msg = str(exc)
+            warnings.warn(
+                f"No credentials found for loaded config file '{self.filepath}'"
+                f" with error '{error_msg}'",
+                SecurePropsNotFoundWarning,
+            )

--- a/src/core/zowe/core_for_zowe_sdk/config_file.py
+++ b/src/core/zowe/core_for_zowe_sdk/config_file.py
@@ -156,10 +156,13 @@ class ConfigFile:
 
         return Profile(props, profile_name, self._secure_props_not_found)
 
-    def autodiscover_config_dir(self):
+    def autodiscover_config_dir(self) -> None:
         """
         Autodiscover Zowe z/OSMF Team Config files by going up the path from
         current working directory
+        Returns
+        -------
+        None
 
         Return path if it finds the config directory,
         Else, it returns None
@@ -184,6 +187,11 @@ class ConfigFile:
 
     def get_profilename_from_profiletype(self, profile_type: str) -> str:
         """
+        Returns profilename from given profiletype as defined in the team config profile
+        Returns
+        -------
+        str
+
         Return exact profilename of the profile to load from the mentioned type
 
         First tries to look into the defaults, if not found,
@@ -220,6 +228,13 @@ class ConfigFile:
 
     def load_profile_properties(self, profile_name: str) -> dict:
         """
+        Load profile properties including secure properties
+        Returns
+        -------
+        dictionary
+
+            Object containing profile properties
+
         Load exact profile properties (without prepopulated fields from base profile)
         from the profile dict and populate fields from the secure credentials storage
         """
@@ -253,7 +268,10 @@ class ConfigFile:
 
     def load_secure_props(self) -> None:
         """
-        load secure_props stored for the given config
+        load secure_props stored for the given config file
+        Returns
+        -------
+        None
 
         if keyring is not initialized, set empty value
         """

--- a/src/core/zowe/core_for_zowe_sdk/custom_warnings.py
+++ b/src/core/zowe/core_for_zowe_sdk/custom_warnings.py
@@ -1,0 +1,30 @@
+class ProfileNotFoundWarning(Warning):
+    def __init__(self, message):
+        self.message = message
+
+    def __str__(self):
+        return repr(self.message)
+
+
+class ProfileParsingWarning(Warning):
+    def __init__(self, message):
+        self.message = message
+
+    def __str__(self):
+        return repr(self.message)
+
+
+class ConfigNotFoundWarning(Warning):
+    def __init__(self, message):
+        self.message = message
+
+    def __str__(self):
+        return repr(self.message)
+
+
+class SecurePropsNotFoundWarning(Warning):
+    def __init__(self, message):
+        self.message = message
+
+    def __str__(self):
+        return repr(self.message)

--- a/src/core/zowe/core_for_zowe_sdk/exceptions.py
+++ b/src/core/zowe/core_for_zowe_sdk/exceptions.py
@@ -128,15 +128,14 @@ class ProfileNotFound(Exception):
 class SecureValuesNotFound(Exception):
     """Class used to represent a profile load failure exception."""
 
-    def __init__(self, values: list):
+    def __init__(self, values: set):
         """
         Parameters
         ----------
         values
             The list of secure values not found
         """
-        list_to_str = ", ".join(map(str, values))
-        super().__init__("Failed to load secure values: {}".format(list_to_str))
+        super().__init__("Failed to load secure values: {}".format(str(values)))
 
 
 class UnsupportedAuthType(Exception):

--- a/src/core/zowe/core_for_zowe_sdk/exceptions.py
+++ b/src/core/zowe/core_for_zowe_sdk/exceptions.py
@@ -11,6 +11,9 @@ Copyright Contributors to the Zowe Project.
 """
 
 
+from typing import Optional
+
+
 class InvalidRequestMethod(Exception):
     """Class used to represent an invalid request method exception."""
 
@@ -108,7 +111,7 @@ class SecureProfileLoadFailed(Exception):
 class ProfileNotFound(Exception):
     """Class used to represent a profile load failure exception."""
 
-    def __init__(self, profile_name, error_msg):
+    def __init__(self, profile_name: Optional[str], error_msg):
         """
         Parameters
         ----------
@@ -117,6 +120,9 @@ class ProfileNotFound(Exception):
         error_msg
             The error message received while trying to load the profile
         """
+        if not profile_name:
+            profile_name = "None"
+
         super().__init__(
             "Failed to load profile {}: {}".format(profile_name, error_msg)
         )

--- a/src/core/zowe/core_for_zowe_sdk/exceptions.py
+++ b/src/core/zowe/core_for_zowe_sdk/exceptions.py
@@ -11,9 +11,6 @@ Copyright Contributors to the Zowe Project.
 """
 
 
-from typing import Optional
-
-
 class InvalidRequestMethod(Exception):
     """Class used to represent an invalid request method exception."""
 
@@ -94,7 +91,7 @@ class MissingConnectionArgs(Exception):
 class SecureProfileLoadFailed(Exception):
     """Class used to represent a secure profile load failure exception."""
 
-    def __init__(self, profile_name, error_msg):
+    def __init__(self, profile_name: str = "unknown", error_msg: str = "error"):
         """
         Parameters
         ----------
@@ -104,14 +101,16 @@ class SecureProfileLoadFailed(Exception):
             The error message received while trying to load the profile
         """
         super().__init__(
-            "Failed to load secure profile {}: {}".format(profile_name, error_msg)
+            "Failed to load secure profile '{}' because '{}'".format(
+                profile_name, error_msg
+            )
         )
 
 
 class ProfileNotFound(Exception):
     """Class used to represent a profile load failure exception."""
 
-    def __init__(self, profile_name: Optional[str], error_msg):
+    def __init__(self, profile_name: str = "unknown", error_msg: str = "error"):
         """
         Parameters
         ----------
@@ -120,11 +119,9 @@ class ProfileNotFound(Exception):
         error_msg
             The error message received while trying to load the profile
         """
-        if not profile_name:
-            profile_name = "None"
 
         super().__init__(
-            "Failed to load profile {}: {}".format(profile_name, error_msg)
+            "Failed to load profile '{}' because '{}'".format(profile_name, error_msg)
         )
 
 
@@ -138,8 +135,8 @@ class SecureValuesNotFound(Exception):
         values
             The list of secure values not found
         """
-        listToStr = ", ".join(map(str, values))
-        super().__init__("Failed to load secure values: {}".format(listToStr))
+        list_to_str = ", ".join(map(str, values))
+        super().__init__("Failed to load secure values: {}".format(list_to_str))
 
 
 class UnsupportedAuthType(Exception):

--- a/src/core/zowe/core_for_zowe_sdk/profile_constants.py
+++ b/src/core/zowe/core_for_zowe_sdk/profile_constants.py
@@ -1,6 +1,9 @@
-# Profile Type
+# Config Type
 USER_CONFIG = "user_config"
 TEAM_CONFIG = "team_config"
 
 # Global File Suffixes
 GLOBAL_CONFIG_NAME = "zowe"
+
+# Profile Type
+BASE_PROFILE = "base"

--- a/src/core/zowe/core_for_zowe_sdk/profile_constants.py
+++ b/src/core/zowe/core_for_zowe_sdk/profile_constants.py
@@ -1,0 +1,6 @@
+# Profile Type
+USER_CONFIG = "user_config"
+TEAM_CONFIG = "team_config"
+
+# Global File Suffixes
+GLOBAL_CONFIG_NAME = "zowe"

--- a/src/core/zowe/core_for_zowe_sdk/profile_manager.py
+++ b/src/core/zowe/core_for_zowe_sdk/profile_manager.py
@@ -12,7 +12,7 @@ Copyright Contributors to the Zowe Project.
 
 import os.path
 import warnings
-from typing import Tuple, Union
+from typing import Optional, Tuple
 
 from .config_file import ConfigFile
 from .custom_warnings import (
@@ -70,7 +70,7 @@ class ProfileManager:
         return self._appname
 
     @property
-    def config_dir(self) -> Union[str, None]:
+    def config_dir(self) -> Optional[str]:
         """Returns the folder path to where the Zowe z/OSMF Team Project Config files are located."""
         return self.project_config.location
 
@@ -83,7 +83,7 @@ class ProfileManager:
         self.project_user_config.location = dirname
 
     @property
-    def user_config_dir(self) -> Union[str, None]:
+    def user_config_dir(self) -> Optional[str]:
         """Returns the folder path to where the Zowe z/OSMF User Project Config files are located."""
         return self.project_user_config.location
 
@@ -98,15 +98,15 @@ class ProfileManager:
         return self.project_config.filename
 
     @property
-    def config_filepath(self) -> Union[str, None]:
+    def config_filepath(self) -> Optional[str]:
         """Get the full Zowe z/OSMF Team Project Config filepath"""
         return self.project_config.filepath
 
     @staticmethod
     def get_profile(
         cfg: ConfigFile,
-        profile_name: Union[str, None],
-        profile_type: Union[str, None],
+        profile_name: Optional[str],
+        profile_type: Optional[str],
         config_type: str,
     ) -> Tuple[dict, str]:
         """Get just the profile from the config file (overriden with base props in the config file)"""
@@ -162,8 +162,8 @@ class ProfileManager:
 
     def load(
         self,
-        profile_name: Union[str, None] = None,
-        profile_type: Union[str, None] = None,
+        profile_name: Optional[str] = None,
+        profile_type: Optional[str] = None,
     ) -> dict:
         if profile_name is None and profile_type is None:
             raise ProfileNotFound(
@@ -174,8 +174,8 @@ class ProfileManager:
         project_profile: dict = {}
         global_profile: dict = {}
         global_base_profile: dict = {}
-        project_profile_name: Union[str, None] = None
-        global_profile_name: Union[str, None] = None
+        project_profile_name: Optional[str] = None
+        global_profile_name: Optional[str] = None
 
         # get Project Profile
         project_profile, project_profile_name = self.get_profile(

--- a/src/core/zowe/core_for_zowe_sdk/profile_manager.py
+++ b/src/core/zowe/core_for_zowe_sdk/profile_manager.py
@@ -198,7 +198,7 @@ class ProfileManager:
         global_base_profile, global_base_profile_name = self.get_profile(
             self.global_config,
             profile_name=None,
-            profile_type="base",
+            profile_type=BASE_PROFILE,
             config_type="Global Config",
         )
 
@@ -206,7 +206,7 @@ class ProfileManager:
         global_base_user_profile, global_base_user_profile_name = self.get_profile(
             self.global_user_config,
             profile_name=None,
-            profile_type="base",
+            profile_type=BASE_PROFILE,
             config_type="Global User Config",
         )
         global_base_profile.update(global_base_user_profile)

--- a/src/core/zowe/core_for_zowe_sdk/profile_manager.py
+++ b/src/core/zowe/core_for_zowe_sdk/profile_manager.py
@@ -132,10 +132,16 @@ class ProfileManager:
                 profile_name=profile_name, profile_type=profile_type
             )
         except ProfileNotFound:
-            warnings.warn(
-                f"Profile '{profile_name}' not found in file '{cfg.filename}', returning empty profile instead.",
-                ProfileNotFoundWarning,
-            )
+            if profile_name:
+                warnings.warn(
+                    f"Profile '{profile_name}' not found in file '{cfg.filename}', returning empty profile instead.",
+                    ProfileNotFoundWarning,
+                )
+            else:
+                warnings.warn(
+                    f"Profile of type '{profile_type}' not found in file '{cfg.filename}', returning empty profile instead.",
+                    ProfileNotFoundWarning,
+                )
         except SecureProfileLoadFailed:
             warnings.warn(
                 f"Config '{cfg.filename}' has no saved secure properties.",

--- a/src/core/zowe/core_for_zowe_sdk/profile_manager.py
+++ b/src/core/zowe/core_for_zowe_sdk/profile_manager.py
@@ -214,16 +214,16 @@ class ProfileManager:
         # get Global Profile
         global_profile, global_profile_name = self.get_profile(
             self.global_config,
-            profile_name=None,
-            profile_type="base",
+            profile_name=profile_name,
+            profile_type=profile_type,
             config_type="Global Config",
         )
 
         # get Global User Profile
         global_user_profile, global_user_profile_name = self.get_profile(
             self.global_user_config,
-            profile_name=None,
-            profile_type="base",
+            profile_name=profile_name,
+            profile_type=profile_type,
             config_type="Global User Config",
         )
         global_profile.update(global_user_profile)

--- a/src/core/zowe/core_for_zowe_sdk/profile_manager.py
+++ b/src/core/zowe/core_for_zowe_sdk/profile_manager.py
@@ -138,7 +138,7 @@ class ProfileManager:
                 )
         except Exception as exc:
             warnings.warn(
-                f"Could not load {config_type} '{cfg.filename}' at '{cfg.filepath}' with exception '{exc}'",
+                f"Could not load {config_type} '{cfg.filename}' at '{cfg.filepath}' with {type(exc).__name__}'{exc}'",
                 ConfigNotFoundWarning,
             )
         finally:

--- a/src/core/zowe/core_for_zowe_sdk/profile_manager.py
+++ b/src/core/zowe/core_for_zowe_sdk/profile_manager.py
@@ -222,10 +222,10 @@ class ProfileManager:
         if profile_type != BASE_PROFILE:
             profile_props = {**self.load(profile_type=BASE_PROFILE), **profile_props}
 
-        missing_props = []
+        missing_props = set()
         for item in missing_secure_props:
             if item not in profile_props.keys():
-                missing_props.extend(item)
+                missing_props.add(item)
 
         if len(missing_props) > 0:
             raise SecureValuesNotFound(values=missing_props)

--- a/src/core/zowe/core_for_zowe_sdk/profile_manager.py
+++ b/src/core/zowe/core_for_zowe_sdk/profile_manager.py
@@ -40,6 +40,12 @@ CURRENT_DIR = os.getcwd()
 
 
 class ProfileManager:
+    """
+    Profile Manager contains the logic to merge the different properties of profiles
+    (from the Project Config and the Project User Config as well as the Global Config and Global User Config).
+    This class handles all the exceptions raised in the Config File to provide a smooth user experience.
+    """
+
     def __init__(self, appname: str = "zowe"):
         self._appname = appname
 
@@ -165,9 +171,36 @@ class ProfileManager:
         profile_name: Optional[str] = None,
         profile_type: Optional[str] = None,
     ) -> dict:
+        """Load z/OSMF connection details from a z/OSMF profile.
+        Returns
+        -------
+        dictionary
+
+            z/OSMF connection object
+        We will be loading properties from a bottom up fashion,
+        the bottom being the base/default profile properties
+        and the up being the explicitly mentioned Profile.
+
+        Profile loading order :
+        1. Global Profile
+            1.1 Global Profile from Global Config (populated with base profile)
+            1.2 Global User Profile from Global User Config (populated with base profile)
+        2. Global Base Profile
+            1.1 Global Base Profile form Global Config
+            1.1 Global Base User Profile from Global User Config
+
+        3. Project Profile
+            3.1 Project Profile from Project Config
+            3.2 Project User Profile from Project User Config
+
+        4.If Global Profile and Project Profile have same profile_name,
+            we do not load defaults from Global Proifle, instead,
+            we user the Global Base Profile
+        """
         if profile_name is None and profile_type is None:
             raise ProfileNotFound(
-                "Could not find profile as both profile_name and profile_type is not set."
+                profile_name=profile_name,
+                error_msg="Could not find profile as both profile_name and profile_type is not set.",
             )
 
         service_profile: dict = {}

--- a/src/core/zowe/core_for_zowe_sdk/profile_manager.py
+++ b/src/core/zowe/core_for_zowe_sdk/profile_manager.py
@@ -138,7 +138,7 @@ class ProfileManager:
                 )
         except Exception as exc:
             warnings.warn(
-                f"Could not load {config_type} '{cfg.filename}' with exception '{exc}'",
+                f"Could not load {config_type} '{cfg.filename}' at '{cfg.filepath}' with exception '{exc}'",
                 ConfigNotFoundWarning,
             )
         finally:

--- a/src/core/zowe/core_for_zowe_sdk/profile_manager.py
+++ b/src/core/zowe/core_for_zowe_sdk/profile_manager.py
@@ -139,7 +139,8 @@ class ProfileManager:
                 )
             else:
                 warnings.warn(
-                    f"Profile of type '{profile_type}' not found in file '{cfg.filename}', returning empty profile instead.",
+                    f"Profile of type '{profile_type}' not found in file '{cfg.filename}', returning empty profile"
+                    f" instead.",
                     ProfileNotFoundWarning,
                 )
         except SecureProfileLoadFailed:
@@ -173,6 +174,7 @@ class ProfileManager:
         self,
         profile_name: Optional[str] = None,
         profile_type: Optional[str] = None,
+        check_missing_props: bool = True,
     ) -> dict:
         """Load connection details from a team config profile.
         Returns
@@ -226,15 +228,20 @@ class ProfileManager:
                 break  # Skip loading from global config if profile was found in project config
 
         if profile_type != BASE_PROFILE:
-            profile_props = {**self.load(profile_type=BASE_PROFILE), **profile_props}
+            profile_props = {
+                **self.load(profile_type=BASE_PROFILE, check_missing_props=False),
+                **profile_props,
+            }
 
-        missing_props = set()
-        for item in missing_secure_props:
-            if item not in profile_props.keys():
-                missing_props.add(item)
+        if check_missing_props:
+            missing_props = set()
+            for item in missing_secure_props:
+                print(item, profile_props.keys())
+                if item not in profile_props.keys():
+                    missing_props.add(item)
 
-        if len(missing_props) > 0:
-            raise SecureValuesNotFound(values=missing_props)
+            if len(missing_props) > 0:
+                raise SecureValuesNotFound(values=missing_props)
 
         warnings.resetwarnings()
 

--- a/src/core/zowe/core_for_zowe_sdk/profile_manager.py
+++ b/src/core/zowe/core_for_zowe_sdk/profile_manager.py
@@ -222,9 +222,13 @@ class ProfileManager:
         if profile_type != BASE_PROFILE:
             profile_props = {**self.load(profile_type=BASE_PROFILE), **profile_props}
 
+        missing_props = []
         for item in missing_secure_props:
             if item not in profile_props.keys():
-                raise SecureValuesNotFound(values=[item])
+                missing_props.extend(item)
+
+        if len(missing_props) > 0:
+            raise SecureValuesNotFound(values=missing_props)
 
         warnings.resetwarnings()
 

--- a/src/core/zowe/core_for_zowe_sdk/session.py
+++ b/src/core/zowe/core_for_zowe_sdk/session.py
@@ -11,7 +11,7 @@ Copyright Contributors to the Zowe Project.
 """
 
 from dataclasses import dataclass
-from typing import Union
+from typing import Optional
 
 from . import session_constants
 
@@ -25,13 +25,13 @@ class ISession:
     host: str
     port: int = session_constants.DEFAULT_HTTPS_PORT
     rejectUnauthorized: bool = True
-    user: Union[str, None] = None
-    password: Union[str, None] = None
+    user: Optional[str] = None
+    password: Optional[str] = None
     protocol: str = session_constants.HTTPS_PROTOCOL
-    basePath: Union[str, None] = None
-    type: Union[str, None] = None
-    tokenType: Union[str, None] = None
-    tokenValue: Union[str, None] = None
+    basePath: Optional[str] = None
+    type: Optional[str] = None
+    tokenType: Optional[str] = None
+    tokenValue: Optional[str] = None
 
 
 class Session:

--- a/tests/unit/fixtures/zowe.config.json
+++ b/tests/unit/fixtures/zowe.config.json
@@ -6,7 +6,7 @@
             "properties": {
                 "port": 10443
             },
-            "secure": []
+            "secure": ["user", "password"]
         },
         "tso": {
             "type": "tso",

--- a/tests/unit/fixtures/zowe.config.json
+++ b/tests/unit/fixtures/zowe.config.json
@@ -15,7 +15,7 @@
                 "codePage": "1047",
                 "logonProcedure": "IZUFPROC"
             },
-            "secure": []
+            "secure": [] // no credentials
         },
         "ssh": {
             "type": "ssh",
@@ -36,12 +36,12 @@
             "type": "base",
             "properties": {
                 "host": "zowe.test.cloud",
-                "rejectUnauthorized": false
+                "rejectUnauthorized": false // this is by default
             },
             "secure": [
                 "user",
                 "password"
-            ]
+            ] // credentials are generally obtained from keyring
         }
     },
     "defaults": {

--- a/tests/unit/fixtures/zowe.config.user.json
+++ b/tests/unit/fixtures/zowe.config.user.json
@@ -1,0 +1,31 @@
+{
+    "$schema": "./zowe.schema.json",
+    "profiles": {
+        "zosmf": {
+            "type": "zosmf",
+            "properties": {
+                "port": 10000 // overridden property
+            },
+            "secure": []
+        },
+        "base": {
+            "type": "base",
+            "properties": {
+                "host": "zowe.test.user.cloud", // overriden property
+                "rejectUnauthorized": false // this is by default
+            },
+            "secure": [
+                "user",
+                "password"
+            ] // credentials are generally obtained from keyring
+        }
+    },
+    "defaults": {
+        "zosmf": "zosmf",
+        "tso": "tso",
+        "ssh": "ssh",
+        "zftp": "zftp",
+        "base": "base"
+    },
+    "autoStore": true
+}

--- a/tests/unit/test_zowe_core.py
+++ b/tests/unit/test_zowe_core.py
@@ -167,7 +167,9 @@ class TestZosmfProfileManager(TestCase):
         # setup pyfakefs
         self.setUpPyfakefs()
         self.original_file_path = os.path.join(FIXTURES_PATH, "zowe.config.json")
-        self.original_user_file_path = os.path.join(FIXTURES_PATH, "zowe.config.user.json")
+        self.original_user_file_path = os.path.join(
+            FIXTURES_PATH, "zowe.config.user.json"
+        )
         self.fs.add_real_file(self.original_file_path)
         self.fs.add_real_file(self.original_user_file_path)
 

--- a/tests/unit/test_zowe_core.py
+++ b/tests/unit/test_zowe_core.py
@@ -217,8 +217,7 @@ class TestZosmfProfileManager(TestCase):
         # Test
         prof_manager = ProfileManager()
         props: dict = prof_manager.load(profile_type="base")
-
-        assert(prof_manager.config_filepath == cwd_up_file_path)
+        self.assertEqual(prof_manager.config_filepath, cwd_up_file_path)
 
         expected_props = {
             "host": "zowe.test.cloud",
@@ -248,6 +247,8 @@ class TestZosmfProfileManager(TestCase):
         prof_manager = ProfileManager(appname=self.custom_appname)
         prof_manager.config_dir = self.custom_dir
         props: dict = prof_manager.load(profile_name="zosmf")
+        self.assertEqual(prof_manager.config_filepath, custom_file_path)
+
         expected_props = {
             "host": "zowe.test.cloud",
             "rejectUnauthorized": False,
@@ -279,6 +280,8 @@ class TestZosmfProfileManager(TestCase):
         # Test
         prof_manager = ProfileManager()
         props: dict = prof_manager.load(profile_type="zosmf")
+        self.assertEqual(prof_manager.config_filepath, cwd_up_file_path)
+
         expected_props = {
             "host": "zowe.test.user.cloud",
             "rejectUnauthorized": False,


### PR DESCRIPTION
Now the Profile Manager class has been split into two parts :

- Config File : This just concerns itself with just one file. It handles all the auto-discovering and loading of profiles (prepopulated form base profile properties or just the profile properties). It always raises exceptions when it faces any.

- ProfileManager : This class contains the logic to merge the different properties of profiles (from the Project Config and the Project User Config as well as the Global Config and Global User Config). This class handles all the exceptions raised in the Config File to provide a smooth user experience.

Config File is recommended when the user wants to load just one file while ProfileManager automates the merging of profiles.

This is the duplicate of #113 since I had to rebase against the next branch