### PR TITLE
Fix minor stuff observed in peer review

### DIFF
--- a/src/core/zowe/core_for_zowe_sdk/request_handler.py
+++ b/src/core/zowe/core_for_zowe_sdk/request_handler.py
@@ -143,7 +143,7 @@ class RequestHandler:
         A bytes object if the response content type is application/octet-stream,
         a normalized JSON for the request response otherwise
         """  
-        if self.response.headers['Content-Type'] == 'application/octet-stream':
+        if self.response.headers.get('Content-Type') == 'application/octet-stream':
             return self.response.content
         else:
             try:

--- a/src/zos_files/zowe/zos_files_for_zowe_sdk/files.py
+++ b/src/zos_files/zowe/zos_files_for_zowe_sdk/files.py
@@ -16,7 +16,6 @@ from zowe.core_for_zowe_sdk.exceptions import FileNotFound
 from zowe.zos_files_for_zowe_sdk import exceptions, constants
 import os
 import shutil
-import json
 from zowe.zos_files_for_zowe_sdk.constants import zos_file_constants
 
 _ZOWE_FILES_DEFAULT_ENCODING='utf-8'
@@ -587,7 +586,7 @@ class Files(SdkApi):
 
         data = {
             "request": "hrecall",
-            "wait": json.dumps(wait)
+            "wait": wait
         }
 
         custom_args = self._create_custom_request_arguments()
@@ -619,8 +618,8 @@ class Files(SdkApi):
 
         data = {
             "request": "hdelete",
-            "purge": json.dumps(purge),
-            "wait": json.dumps(wait), 
+            "purge": purge,
+            "wait": wait,
         }
 
         custom_args = self._create_custom_request_arguments()
@@ -649,7 +648,7 @@ class Files(SdkApi):
 
         data = {
             "request": "hmigrate",
-            "wait": json.dumps(wait)
+            "wait": wait
         }
 
         custom_args = self._create_custom_request_arguments()

--- a/tests/unit/test_zos_console.py
+++ b/tests/unit/test_zos_console.py
@@ -9,7 +9,7 @@ class TestConsoleClass(unittest.TestCase):
 
     def setUp(self):
         """Setup fixtures for Console class."""
-        self.session_details = {"host": "https://mock-url.com",
+        self.session_details = {"host": "mock-url.com",
                                 "user": "Username",
                                 "password": "Password",
                                 "port": 443,

--- a/tests/unit/test_zos_files.py
+++ b/tests/unit/test_zos_files.py
@@ -1,7 +1,6 @@
 """Unit tests for the Zowe Python SDK z/OS Files package."""
 from unittest import TestCase, mock
 from zowe.zos_files_for_zowe_sdk import Files, exceptions
-import json
 
 
 class TestFilesClass(TestCase):
@@ -9,7 +8,7 @@ class TestFilesClass(TestCase):
 
     def setUp(self):
         """Setup fixtures for File class."""
-        self.test_profile = {"host": "https://mock-url.com",
+        self.test_profile = {"host": "mock-url.com",
                                 "user": "Username",
                                 "password": "Password",
                                 "port": 443,
@@ -106,13 +105,13 @@ class TestFilesClass(TestCase):
 
             data = {
                 "request": "hrecall",
-                "wait": json.dumps(test_case[1])
+                "wait": test_case[1]
             }
 
             files_test_profile.recall_migrated_dataset(test_case[0], test_case[1])
             custom_args = files_test_profile._create_custom_request_arguments()
             custom_args["json"] = data
-            custom_args["url"] = "https://https://mock-url.com:443/zosmf/restfiles/ds/{}".format(test_case[0])
+            custom_args["url"] = "https://mock-url.com:443/zosmf/restfiles/ds/{}".format(test_case[0])
             files_test_profile.request_handler.perform_request.assert_called_once_with("PUT", custom_args, expected_code=[200])
 
     @mock.patch('requests.Session.send')
@@ -142,15 +141,15 @@ class TestFilesClass(TestCase):
 
             data = {
                 "request": "hdelete",
-                "purge": json.dumps(test_case[1]),
-                "wait": json.dumps(test_case[2]),
+                "purge": test_case[1],
+                "wait": test_case[2],
 
             }
 
             files_test_profile.delete_migrated_data_set(test_case[0], test_case[1], test_case[2])
             custom_args = files_test_profile._create_custom_request_arguments()
             custom_args["json"] = data
-            custom_args["url"] = "https://https://mock-url.com:443/zosmf/restfiles/ds/{}".format(test_case[0])
+            custom_args["url"] = "https://mock-url.com:443/zosmf/restfiles/ds/{}".format(test_case[0])
             files_test_profile.request_handler.perform_request.assert_called_once_with("PUT", custom_args, expected_code=[200])
 
     @mock.patch('requests.Session.send')
@@ -178,14 +177,14 @@ class TestFilesClass(TestCase):
 
             data = {
                 "request": "hmigrate",
-                "wait": json.dumps(test_case[1]),
+                "wait": test_case[1],
             }
 
             files_test_profile.migrate_data_set(test_case[0], test_case[1])
 
             custom_args = files_test_profile._create_custom_request_arguments()
             custom_args["json"] = data
-            custom_args["url"] = "https://https://mock-url.com:443/zosmf/restfiles/ds/{}".format(test_case[0])
+            custom_args["url"] = "https://mock-url.com:443/zosmf/restfiles/ds/{}".format(test_case[0])
             files_test_profile.request_handler.perform_request.assert_called_once_with("PUT", custom_args, expected_code=[200])
 
     @mock.patch('requests.Session.send')
@@ -220,7 +219,7 @@ class TestFilesClass(TestCase):
 
             custom_args = files_test_profile._create_custom_request_arguments()
             custom_args["json"] = data
-            custom_args["url"] = "https://https://mock-url.com:443/zosmf/restfiles/ds/{}".format(test_case[0][1])
+            custom_args["url"] = "https://mock-url.com:443/zosmf/restfiles/ds/{}".format(test_case[0][1])
             files_test_profile.request_handler.perform_request.assert_called_once_with("PUT", custom_args, expected_code=[200])
 
     @mock.patch('requests.Session.send')
@@ -266,7 +265,7 @@ class TestFilesClass(TestCase):
                 files_test_profile.rename_dataset_member(*test_case[0])
                 custom_args = files_test_profile._create_custom_request_arguments()
                 custom_args["json"] = data
-                custom_args["url"] = "https://https://mock-url.com:443/zosmf/restfiles/ds/{}({})".format(
+                custom_args["url"] = "https://mock-url.com:443/zosmf/restfiles/ds/{}({})".format(
                     test_case[0][0], test_case[0][2])
                 files_test_profile.request_handler.perform_request.assert_called_once_with("PUT", custom_args,
                                                                                            expected_code=[200])
@@ -396,7 +395,7 @@ class TestFilesClass(TestCase):
                 files_test_profile.create_data_set(*test_case[0])
                 custom_args = files_test_profile._create_custom_request_arguments()
                 custom_args["json"] = test_case[0][1]
-                custom_args["url"] = "https://https://mock-url.com:443/zosmf/restfiles/ds/{}".format(test_case[0][0])
+                custom_args["url"] = "https://mock-url.com:443/zosmf/restfiles/ds/{}".format(test_case[0][0])
                 files_test_profile.request_handler.perform_request.assert_called_once_with("POST", custom_args, expected_code=[201])
             else:
                 with self.assertRaises(ValueError) as e_info:
@@ -478,7 +477,7 @@ class TestFilesClass(TestCase):
                 files_test_profile.create_default_data_set(*test_case[0])
                 custom_args = files_test_profile._create_custom_request_arguments()
                 custom_args["json"] = options.get(test_case[0][1])
-                custom_args["url"] = "https://https://mock-url.com:443/zosmf/restfiles/ds/{}".format(test_case[0][0])
+                custom_args["url"] = "https://mock-url.com:443/zosmf/restfiles/ds/{}".format(test_case[0][0])
                 files_test_profile.request_handler.perform_request.assert_called_once_with("POST", custom_args, expected_code=[201])
             else:
                 with self.assertRaises(ValueError) as e_info:

--- a/tests/unit/test_zos_jobs.py
+++ b/tests/unit/test_zos_jobs.py
@@ -10,7 +10,7 @@ class TestJobsClass(TestCase):
     def setUp(self):
         """Setup fixtures for Jobs class."""
         self.test_profile = {
-            "host": "https://mock-url.com",
+            "host": "mock-url.com",
             "user": "Username",
             "password": "Password",
             "port": 443,
@@ -52,7 +52,7 @@ class TestJobsClass(TestCase):
                     "request": "cancel",
                     "version": test_case[0][2],
                 }
-                custom_args["url"] = "https://https://mock-url.com:443/zosmf/restjobs/jobs/{}/{}".format(test_case[0][0], test_case[0][1])
+                custom_args["url"] = "https://mock-url.com:443/zosmf/restjobs/jobs/{}/{}".format(test_case[0][0], test_case[0][1])
                 jobs_test_object.request_handler.perform_request.assert_called_once_with("PUT", custom_args, expected_code=[202, 200])
             else:
                 with self.assertRaises(ValueError) as e_info:

--- a/tests/unit/test_zos_tso.py
+++ b/tests/unit/test_zos_tso.py
@@ -9,7 +9,7 @@ class TestTsoClass(unittest.TestCase):
 
     def setUp(self):
         """Setup fixtures for Tso class."""
-        self.connection_dict = {"host": "https://mock-url.com",
+        self.connection_dict = {"host": "mock-url.com",
                                 "user": "Username",
                                 "password": "Password",
                                 "port": 443,

--- a/tests/unit/test_zosmf.py
+++ b/tests/unit/test_zosmf.py
@@ -10,7 +10,7 @@ class TestZosmfClass(unittest.TestCase):
 
     def setUp(self):
         """Setup fixtures for Zosmf class."""
-        self.connection_dict = {"host": "https://mock-url.com",
+        self.connection_dict = {"host": "mock-url.com",
                                 "user": "Username",
                                 "password": "Password",
                                 "port": 443,

--- a/tests/unit/test_zowe_core.py
+++ b/tests/unit/test_zowe_core.py
@@ -75,8 +75,9 @@ class TestSdkApiClass(TestCase):
     def setUp(self):
         """Setup fixtures for SdkApi class."""
         common_props = {
-            "host": "https://mock-url.com",
+            "host": "mock-url.com",
             "port": 443,
+            "protocol": "https",
             "rejectUnauthorized": True
         }
         self.basic_props = {


### PR DESCRIPTION
* Fix error when "Content-Type" header missing from response
* Remove unnecessary calls to `json.dumps`
* Fix "https://" protocol duplicated in unit tests