### PR TITLE
Create zip bundle for GitHub release

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -45,6 +45,12 @@ jobs:
     - name: Build dist wheels
       run: bash build.sh
 
+    - name: Create zip bundle
+      working-directory: dist
+      run: |
+        pip download -f . zowe-${{ steps.update-version.outputs.version }}-py3-none-any.whl
+        zip zowe-python-sdk-${{ steps.update-version.outputs.version }}.zip *.whl
+
     - name: Commit version update
       uses: stefanzweifel/git-auto-commit-action@v4
       with:
@@ -58,5 +64,5 @@ jobs:
     - name: Create GitHub release
       uses: softprops/action-gh-release@v1
       with:
-        files: 'dist/*.whl'
+        files: 'dist/zowe-python-sdk-${{ steps.update-version.outputs.version }}.zip'
         tag_name: v${{ steps.update-version.outputs.version }}

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ pip install zowe.<subpackage>_for_zowe_sdk
 
 For more information on the available sub-packages click [HERE](https://zowe-client-python-sdk.readthedocs.io/en/next/packages/packages.html)
 
-**Note**: You can also install prerelease versions of the Zowe SDK from GitHub with the following command where "&lt;tagName&gt;" is the latest GitHub release tag:
+**Note**: You can also install prerelease versions of the Zowe SDK from GitHub. Download the ZIP file from the [latest release](https://github.com/zowe/zowe-client-python-sdk/releases/latest), extract it, and run the following command:
 
 ```
-pip install -f https://github.com/zowe/zowe-client-python-sdk/releases/tag/<tagName> zowe>=1.0.0.dev0
+pip install --no-index --no-deps <path where zip is extracted>/*.whl
 ```
 
 ## Requirements


### PR DESCRIPTION
Since running `pip install` from a GitHub release seems to no longer work, and some folks have expressed interest in doing an offline install from wheels, this PR creates a zip bundle in the release workflow 😛 This bundle is structured identically to the Python SDK bundle that is published on zowe.org.