### PR TITLE
[zos-console] Added method to get a command response

### DIFF
--- a/src/zos_console/zowe/zos_console_for_zowe_sdk/console.py
+++ b/src/zos_console/zowe/zos_console_for_zowe_sdk/console.py
@@ -43,3 +43,24 @@ class Console(SdkApi):
         custom_args["json"] = request_body
         response_json = self.request_handler.perform_request("PUT", custom_args)
         return response_json
+
+    def get_response(self, response_key, console=None):
+        """
+        Collect outstanding synchronous z/OS Console response messages.
+        
+        Parameters
+        ----------
+        response_key
+            The command response key from the Issue Command request.
+        console
+            The console that should be used to get the command response.
+        Returns
+        -------
+        json
+            A JSON containing the response to the command
+        """
+        custom_args = self._create_custom_request_arguments()
+        request_url = "{}/solmsgs/{}".format(console or "defcn", response_key)
+        custom_args["url"] = self.request_endpoint.replace("defcn", request_url)
+        response_json = self.request_handler.perform_request("GET", custom_args)
+        return response_json

--- a/tests/integration/test_zos_console.py
+++ b/tests/integration/test_zos_console.py
@@ -17,4 +17,8 @@ class TestConsoleIntegration(unittest.TestCase):
         command_output = self.console.issue_command("D T")
         self.assertTrue(command_output['cmd-response'].strip().startswith("IEE136I"))
 
-
+    def test_get_response_should_return_messages(self):
+        """Test that response message can be received from the console"""
+        command_output = self.console.issue_command("D T")
+        response = self.console.get_response(command_output["cmd-response-key"])
+        self.assertTrue("cmd-response" in response)

--- a/tests/unit/test_zos_console.py
+++ b/tests/unit/test_zos_console.py
@@ -1,6 +1,7 @@
 """Unit tests for the Zowe Python SDK z/OS Console package."""
 
 import unittest
+from unittest import mock
 from zowe.zos_console_for_zowe_sdk import Console
 
 
@@ -20,3 +21,11 @@ class TestConsoleClass(unittest.TestCase):
         """Created object should be instance of Console class."""
         console = Console(self.session_details)
         self.assertIsInstance(console, Console)
+    
+    @mock.patch('requests.Session.send')
+    def test_get_response_should_return_messages(self, mock_send_request):
+       """Getting z/OS Console response messages on sending a response key"""
+       mock_send_request.return_value = mock.Mock(headers={"Content-type": "application/json"}, status_codes=200)
+
+       Console(self.session_details).get_response(self)
+       mock_send_request.assert_called_once()

--- a/tests/unit/test_zos_console.py
+++ b/tests/unit/test_zos_console.py
@@ -27,5 +27,5 @@ class TestConsoleClass(unittest.TestCase):
        """Getting z/OS Console response messages on sending a response key"""
        mock_send_request.return_value = mock.Mock(headers={"Content-type": "application/json"}, status_codes=200)
 
-       Console(self.session_details).get_response(self)
+       Console(self.session_details).get_response("console-key")
        mock_send_request.assert_called_once()


### PR DESCRIPTION
Added a method to call the z/OSMF REST API `GET /zosmf/restconsoles/consoles/<console-name>/solmsgs/C<key-number>`
Signed-off-by: Aaditya Sinha [aadityasinha009@gmail.com](mailto:aadityasinha009@gmail.com)
Resolves #78 