### PR TITLE
Fix missing commentjson dependency for core SDK

### DIFF
--- a/src/core/setup.py
+++ b/src/core/setup.py
@@ -16,6 +16,6 @@ setup(
         "Programming Language :: Python :: 3.7",
         "License :: OSI Approved :: Eclipse Public License 2.0 (EPL-2.0)",
     ],
-    install_requires=["requests", "urllib3", "pyyaml", "jsoncparser"],
+    install_requires=["requests", "urllib3", "pyyaml", "commentjson"],
     packages=find_namespace_packages(include=["zowe.*"]),
 )


### PR DESCRIPTION
Broken docs in "next" branch: https://zowe-client-python-sdk.readthedocs.io/en/next/classes/zos_jobs/jobs.html
Fixed docs for this PR: https://zowe-client-python-sdk--146.org.readthedocs.build/en/146/classes/zos_jobs/jobs.html