### PR TITLE
Reduce duplication of Codecov uploads

### DIFF
--- a/.github/workflows/sdk-build.yml
+++ b/.github/workflows/sdk-build.yml
@@ -14,6 +14,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+    env:
+      OS: ${{ matrix.os }}
+      PYTHON: ${{ matrix.python-version }}
 
     steps:
     - uses: actions/checkout@v3
@@ -39,8 +42,10 @@ jobs:
         coverage xml
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
+      if: ${{ matrix.python-version == '3.7' }}
       with:
         directory: ./
+        env_vars: OS,PYTHON
         fail_ci_if_error: true
         files: ./coverage.xml
         flags: unittests

--- a/.github/workflows/sdk-build.yml
+++ b/.github/workflows/sdk-build.yml
@@ -42,7 +42,7 @@ jobs:
         coverage xml
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
-      if: ${{ matrix.python-version == '3.7' }}
+      if: ${{ matrix.python-version == '3.11' }}
       with:
         directory: ./
         env_vars: OS,PYTHON


### PR DESCRIPTION
Codecov was uploading coverage info for every OS and Python version which seems a bit excessive 😋 
Sometimes this was causing the build to fail.
This PR reduces the Codecov check to run only once per OS.