### PR TITLE
Format all code with black and isort

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,16 +5,20 @@
 # Required
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/source/conf.py
 
 # Optionally build your docs in additional formats such as PDF
-formats: 
+formats:
   - pdf
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
   install:
     - requirements: docs/requirements.txt

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "editor.formatOnSave": true,
+    "python.formatting.provider": "black",
+    "[python]": {
+        "editor.codeActionsOnSave": {
+            "source.organizeImports": true
+        }
+    }
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,4 +67,4 @@ This project follows the [PEP 8](https://www.python.org/dev/peps/pep-0008/) styl
 
 This project also uses `flake8` for code linting. Make sure to run `flake8` on your code before submitting a pull request.
 
-We recommend using `black` as a code formatter. Please format your code using `black` before creating a pull request.
+We recommend using `black` and `isort` as code formatters. Please format your code using these tools before creating a pull request.

--- a/docs/source/_ext/zowe_autodoc.py
+++ b/docs/source/_ext/zowe_autodoc.py
@@ -52,16 +52,15 @@ def main():
             py_name = os.path.basename(py_file)
             if py_name == "__init__.py":
                 continue
-            with open(py_file, 'r', encoding="utf-8") as f:
+            with open(py_file, "r", encoding="utf-8") as f:
                 py_contents = f.read()
             class_names = re.findall(r"^class (\w+)\b", py_contents, re.MULTILINE)
             if len(class_names) == 1:
                 rst_name = f"{py_name[:-3]}.rst"
-                rst_contents = render_template(CLASS_TEMPLATE, {
-                    "fullname": f"{sdk_name}.{pkg_name}.{class_names[0]}",
-                    "header": class_names[0]
-                })
-                with open(f"docs/source/classes/{sdk_name}/{rst_name}", 'w', encoding="utf-8") as f:
+                rst_contents = render_template(
+                    CLASS_TEMPLATE, {"fullname": f"{sdk_name}.{pkg_name}.{class_names[0]}", "header": class_names[0]}
+                )
+                with open(f"docs/source/classes/{sdk_name}/{rst_name}", "w", encoding="utf-8") as f:
                     f.write(rst_contents)
                 rst_names.append(rst_name)
             elif len(class_names) > 1:
@@ -70,39 +69,44 @@ def main():
                 child_rst_names = []
                 for class_name in sorted(class_names):
                     rst_name = f"{class_name.lower()}.rst"
-                    rst_contents = render_template(CLASS_TEMPLATE, {
-                        "fullname": f"{sdk_name}.{pkg_name}.{module_name}.{class_name}",
-                        "header": class_name
-                    })
-                    with open(f"docs/source/classes/{sdk_name}/{module_name}/{rst_name}", 'w', encoding="utf-8") as f:
+                    rst_contents = render_template(
+                        CLASS_TEMPLATE,
+                        {"fullname": f"{sdk_name}.{pkg_name}.{module_name}.{class_name}", "header": class_name},
+                    )
+                    with open(f"docs/source/classes/{sdk_name}/{module_name}/{rst_name}", "w", encoding="utf-8") as f:
                         f.write(rst_contents)
                     child_rst_names.append(rst_name)
                 rst_name = f"{module_name}/index.rst"
-                rst_contents = render_template(INDEX_TEMPLATE, {
-                    "filelist": "\n   ".join(name[:-4] for name in child_rst_names),
-                    "header": f"{module_name.replace('_', ' ').title()} classes",
-                    "maxdepth": 2
-                })
-                with open(f"docs/source/classes/{sdk_name}/{rst_name}", 'w', encoding="utf-8") as f:
+                rst_contents = render_template(
+                    INDEX_TEMPLATE,
+                    {
+                        "filelist": "\n   ".join(name[:-4] for name in child_rst_names),
+                        "header": f"{module_name.replace('_', ' ').title()} classes",
+                        "maxdepth": 2,
+                    },
+                )
+                with open(f"docs/source/classes/{sdk_name}/{rst_name}", "w", encoding="utf-8") as f:
                     f.write(rst_contents)
                 parent_rst_names.append(rst_name)
 
-        rst_contents = render_template(INDEX_TEMPLATE, {
-            "filelist": "\n   ".join(name[:-4] for name in rst_names + parent_rst_names),
-            "header": pkg_name,
-            "maxdepth": 2
-        })
-        with open(f"docs/source/classes/{sdk_name}/index.rst", 'w', encoding="utf-8") as f:
+        rst_contents = render_template(
+            INDEX_TEMPLATE,
+            {
+                "filelist": "\n   ".join(name[:-4] for name in rst_names + parent_rst_names),
+                "header": pkg_name,
+                "maxdepth": 2,
+            },
+        )
+        with open(f"docs/source/classes/{sdk_name}/index.rst", "w", encoding="utf-8") as f:
             f.write(rst_contents)
         sdk_names.append(sdk_name)
         print("done")
 
-    rst_contents = render_template(INDEX_TEMPLATE, {
-        "filelist": "\n   ".join(f"{name}/index" for name in sdk_names),
-        "header": "Classes",
-        "maxdepth": 3
-    })
-    with open(f"docs/source/classes/index.rst", 'w', encoding="utf-8") as f:
+    rst_contents = render_template(
+        INDEX_TEMPLATE,
+        {"filelist": "\n   ".join(f"{name}/index" for name in sdk_names), "header": "Classes", "maxdepth": 3},
+    )
+    with open(f"docs/source/classes/index.rst", "w", encoding="utf-8") as f:
         f.write(rst_contents)
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,16 +13,16 @@
 import os
 import sys
 from datetime import date
-sys.path.insert(0, os.path.abspath('../../src'))
-sys.path.append(os.path.abspath('./_ext'))
-from _version import __version__
 
+sys.path.insert(0, os.path.abspath("../../src"))
+sys.path.append(os.path.abspath("./_ext"))
+from _version import __version__
 
 # -- Project information -----------------------------------------------------
 
-project = 'Zowe Client Python SDK'
-copyright = f'{date.today().year}, Contributors to the Zowe Project'
-author = 'Contributors to the Zowe Project'
+project = "Zowe Client Python SDK"
+copyright = f"{date.today().year}, Contributors to the Zowe Project"
+author = "Contributors to the Zowe Project"
 
 # The full version, including alpha/beta/rc tags
 release = __version__
@@ -33,12 +33,14 @@ release = __version__
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.autodoc',
-              'sphinx.ext.coverage',
-              'sphinx.ext.napoleon',
-              'sphinx_rtd_theme',
-              'sphinxcontrib.spelling',
-              'zowe_autodoc']
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.coverage",
+    "sphinx.ext.napoleon",
+    "sphinx_rtd_theme",
+    "sphinxcontrib.spelling",
+    "zowe_autodoc",
+]
 
 # Napoleon options
 napoleon_google_docstring = False
@@ -56,7 +58,7 @@ napoleon_type_aliases = None
 
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -69,11 +71,11 @@ exclude_patterns = []
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
-html_logo = '_static/zowe-white.png'
+html_logo = "_static/zowe-white.png"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.black]
+line-length = 120
+
+[tool.isort]
+profile = "black"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+black
 certifi==2023.7.22
 chardet==4.0.0
 colorama==0.4.4
@@ -7,6 +8,7 @@ deepmerge==1.1.0
 flake8==3.8.4
 idna==2.10
 importlib-metadata==3.6.0
+isort
 jsonschema==4.17.3
 keyring
 lxml==4.9.3
@@ -28,7 +30,6 @@ Unidecode==1.2.0
 urllib3==1.26.5
 wheel
 zipp==3.4.0
-black
 -e ./src/core
 -e ./src/zos_console
 -e ./src/zos_files

--- a/samples/SampleConsole.py
+++ b/samples/SampleConsole.py
@@ -2,16 +2,11 @@ from zowe.zos_console_for_zowe_sdk import Console
 
 # Change <xxxx> below to the name of your zosmf profile
 
-connection = {
-    "plugin_profile": "xxxx"
-}
+connection = {"plugin_profile": "xxxx"}
 
 my_console = Console(connection)
-command        = 'D IPLINFO'
+command = "D IPLINFO"
 command_result = my_console.issue_command(command)
-command_output = command_result['cmd-response'].replace('\r','\n')
+command_output = command_result["cmd-response"].replace("\r", "\n")
 
 print(f"Command: {command} \n Output: \n\n{command_output}")
-
-
-   

--- a/samples/SampleFiles.py
+++ b/samples/SampleFiles.py
@@ -2,24 +2,22 @@ from zowe.zos_files_for_zowe_sdk import Files
 
 # Change <xxxx> below to the name of your zosmf profile
 
-connection = {
-    "plugin_profile": "xxxx"
-}
+connection = {"plugin_profile": "xxxx"}
 
 # -----------------------------------------------------
 # print list of zos datasets
-# ----------------------------------------------------- 
+# -----------------------------------------------------
 print("...SYS1 datasets\n")
 my_files = Files(connection)
 my_dsn_list = my_files.list_dsn("SYS1.**.*")
-datasets = my_dsn_list['items']
+datasets = my_dsn_list["items"]
 for ds in datasets:
-    print(ds['dsname'])
+    print(ds["dsname"])
 
 # -----------------------------------------------------
 # Now try the uss side... Not in the SDK in GitHub yet
 
-# ----------------------------------------------------- 
+# -----------------------------------------------------
 print("...files in /etc\n")
 my_file_list = my_files.list_files("/etc")
 files = my_file_list["items"]
@@ -28,8 +26,7 @@ for file in files:
 
 # -----------------------------------------------------
 # Get the content of one of the files.
-# ----------------------------------------------------- 
+# -----------------------------------------------------
 print("...content of a file\n")
 my_file_content = my_files.get_file_content("/z/tm891807/file.txt")
 print(my_file_content["response"])
-

--- a/samples/SampleJobs.py
+++ b/samples/SampleJobs.py
@@ -1,48 +1,46 @@
-from zowe.zos_jobs_for_zowe_sdk import Jobs
-import time
 import os
+import time
 
+from zowe.zos_jobs_for_zowe_sdk import Jobs
 
 # -----------------------------------------------------
 # Test drive the jobs SDK with jcl from a file
-# ----------------------------------------------------- 
+# -----------------------------------------------------
 # Change <xxxx> below to the name of your zosmf profile
 
-connection = {
-    "plugin_profile": "xxxx"
-}
+connection = {"plugin_profile": "xxxx"}
 
 
 print("...Submit a sleeper job\n")
 my_jobs = Jobs(connection)
 job = my_jobs.submit_from_local_file("jcl\sleep.jcl")
-job_name   = job['jobname']
-job_id     = job['jobid']
+job_name = job["jobname"]
+job_id = job["jobid"]
 print(f"Job {job_name} ID {job_id} submitted")
 
 # -----------------------------------------------------
 # Wait until the job completes
-# ----------------------------------------------------- 
+# -----------------------------------------------------
 
 boolJobNotDone = True
 while boolJobNotDone:
-    status = my_jobs.get_job_status(job_name,job_id)
-    job_status = status['status']
-    if job_status != 'OUTPUT':
+    status = my_jobs.get_job_status(job_name, job_id)
+    job_status = status["status"]
+    if job_status != "OUTPUT":
         print(f"Status {job_status}")
         time.sleep(5)
     else:
         boolJobNotDone = False
 
 # -----------------------------------------------------
-# Get the return code 
-# ----------------------------------------------------- 
-job_retcode    = status['retcode']
-job_correlator = status['job-correlator']
+# Get the return code
+# -----------------------------------------------------
+job_retcode = status["retcode"]
+job_correlator = status["job-correlator"]
 print(f"Job {job_name} ID {job_id} ended with {job_retcode}")
 
 # -----------------------------------------------------
 # Get all the spool files and dump them in <output_dir>
-# ----------------------------------------------------- 
-output_dir    = './output'
-my_jobs.get_job_output_as_files(status,output_dir)
+# -----------------------------------------------------
+output_dir = "./output"
+my_jobs.get_job_output_as_files(status, output_dir)

--- a/src/core/setup.py
+++ b/src/core/setup.py
@@ -1,5 +1,7 @@
 import sys
-from setuptools import setup, find_namespace_packages
+
+from setuptools import find_namespace_packages, setup
+
 sys.path.append("..")
 from _version import __version__
 

--- a/src/core/zowe/core_for_zowe_sdk/__init__.py
+++ b/src/core/zowe/core_for_zowe_sdk/__init__.py
@@ -2,14 +2,14 @@
 Zowe Python SDK - Core package
 """
 
+from .config_file import ConfigFile
 from .connection import ApiConnection
 from .constants import constants
+from .credential_manager import CredentialManager
 from .exceptions import *
 from .profile_manager import ProfileManager
 from .request_handler import RequestHandler
 from .sdk_api import SdkApi
-from .session_constants import *
 from .session import Session
+from .session_constants import *
 from .zosmf_profile import ZosmfProfile
-from .config_file import ConfigFile
-from .credential_manager import CredentialManager

--- a/src/core/zowe/core_for_zowe_sdk/config_file.py
+++ b/src/core/zowe/core_for_zowe_sdk/config_file.py
@@ -21,7 +21,6 @@ from typing import NamedTuple, Optional
 import commentjson
 import requests
 
-from .constants import constants
 from .credential_manager import CredentialManager
 from .custom_warnings import ProfileNotFoundWarning, ProfileParsingWarning
 from .exceptions import ProfileNotFound

--- a/src/core/zowe/core_for_zowe_sdk/connection.py
+++ b/src/core/zowe/core_for_zowe_sdk/connection.py
@@ -27,11 +27,7 @@ class ApiConnection:
     ssl_verification: bool
     """
 
-    def __init__(self,
-                 host_url,
-                 user,
-                 password,
-                 ssl_verification=True):
+    def __init__(self, host_url, user, password, ssl_verification=True):
         """Construct an ApiConnection object."""
         if not host_url or not user or not password:
             raise MissingConnectionArgs()

--- a/src/core/zowe/core_for_zowe_sdk/constants.py
+++ b/src/core/zowe/core_for_zowe_sdk/constants.py
@@ -16,5 +16,5 @@ constants = {
     "ZoweCredentialKey": "Zowe-Plugin",
     "ZoweServiceName": "Zowe",
     "ZoweAccountName": "secure_config_props",
-    "WIN32_CRED_MAX_STRING_LENGTH" : 2560 
+    "WIN32_CRED_MAX_STRING_LENGTH": 2560,
 }

--- a/src/core/zowe/core_for_zowe_sdk/credential_manager.py
+++ b/src/core/zowe/core_for_zowe_sdk/credential_manager.py
@@ -12,12 +12,12 @@ Copyright Contributors to the Zowe Project.
 import base64
 import logging
 import sys
-import warnings
 from typing import Optional
 
 import commentjson
-from zowe.core_for_zowe_sdk import constants
-from zowe.core_for_zowe_sdk.exceptions import SecureProfileLoadFailed
+
+from .constants import constants
+from .exceptions import SecureProfileLoadFailed
 
 HAS_KEYRING = True
 try:

--- a/src/core/zowe/core_for_zowe_sdk/exceptions.py
+++ b/src/core/zowe/core_for_zowe_sdk/exceptions.py
@@ -39,7 +39,9 @@ class UnexpectedStatus(Exception):
             The output from the request
         """
         super().__init__(
-            "The status code from z/OSMF was {} it was expected {}. \n {}".format(received, expected, request_output)
+            "The status code from z/OSMF was: {}\nExpected: {}\nRequest output: {}".format(
+                received, expected, request_output
+            )
         )
 
 

--- a/src/core/zowe/core_for_zowe_sdk/exceptions.py
+++ b/src/core/zowe/core_for_zowe_sdk/exceptions.py
@@ -39,9 +39,7 @@ class UnexpectedStatus(Exception):
             The output from the request
         """
         super().__init__(
-            "The status code from z/OSMF was {} it was expected {}. \n {}".format(
-                received, expected, request_output
-            )
+            "The status code from z/OSMF was {} it was expected {}. \n {}".format(received, expected, request_output)
         )
 
 
@@ -57,11 +55,7 @@ class RequestFailed(Exception):
         request_output
             The output from the request
         """
-        super().__init__(
-            "HTTP Request has failed with status code {}. \n {}".format(
-                status_code, request_output
-            )
-        )
+        super().__init__("HTTP Request has failed with status code {}. \n {}".format(status_code, request_output))
 
 
 class FileNotFound(Exception):
@@ -100,11 +94,7 @@ class SecureProfileLoadFailed(Exception):
         error_msg
             The error message received while trying to load the profile
         """
-        super().__init__(
-            "Failed to load secure profile '{}' because '{}'".format(
-                profile_name, error_msg
-            )
-        )
+        super().__init__("Failed to load secure profile '{}' because '{}'".format(profile_name, error_msg))
 
 
 class ProfileNotFound(Exception):
@@ -120,9 +110,7 @@ class ProfileNotFound(Exception):
             The error message received while trying to load the profile
         """
 
-        super().__init__(
-            "Failed to load profile '{}' because '{}'".format(profile_name, error_msg)
-        )
+        super().__init__("Failed to load profile '{}' because '{}'".format(profile_name, error_msg))
 
 
 class SecureValuesNotFound(Exception):

--- a/src/core/zowe/core_for_zowe_sdk/profile_manager.py
+++ b/src/core/zowe/core_for_zowe_sdk/profile_manager.py
@@ -10,13 +10,14 @@ SPDX-License-Identifier: EPL-2.0
 Copyright Contributors to the Zowe Project.
 """
 
-import os.path
 import os
+import os.path
 import warnings
-import jsonschema
-from typing import Optional
-from deepmerge import always_merger
 from copy import deepcopy
+from typing import Optional
+
+import jsonschema
+from deepmerge import always_merger
 
 from .config_file import ConfigFile, Profile
 from .credential_manager import CredentialManager
@@ -38,9 +39,7 @@ HAS_KEYRING = True
 
 HOME = os.path.expanduser("~")
 GLOBAl_CONFIG_LOCATION = os.path.join(HOME, ".zowe")
-GLOBAL_CONFIG_PATH = os.path.join(
-    GLOBAl_CONFIG_LOCATION, f"{GLOBAL_CONFIG_NAME}.config.json"
-)
+GLOBAL_CONFIG_PATH = os.path.join(GLOBAl_CONFIG_LOCATION, f"{GLOBAL_CONFIG_NAME}.config.json")
 CURRENT_DIR = os.getcwd()
 
 
@@ -58,8 +57,7 @@ class ProfileManager:
         self.project_config = ConfigFile(type=TEAM_CONFIG, name=appname)
         self.project_user_config = ConfigFile(type=USER_CONFIG, name=appname)
 
-        self.global_config = ConfigFile(
-            type=TEAM_CONFIG, name=GLOBAL_CONFIG_NAME)
+        self.global_config = ConfigFile(type=TEAM_CONFIG, name=GLOBAL_CONFIG_NAME)
         try:
             self.global_config.location = GLOBAl_CONFIG_LOCATION
         except Exception:
@@ -68,8 +66,7 @@ class ProfileManager:
                 ConfigNotFoundWarning,
             )
 
-        self.global_user_config = ConfigFile(
-            type=USER_CONFIG, name=GLOBAL_CONFIG_NAME)
+        self.global_user_config = ConfigFile(type=USER_CONFIG, name=GLOBAL_CONFIG_NAME)
         try:
             self.global_user_config.location = GLOBAl_CONFIG_LOCATION
         except Exception:
@@ -138,24 +135,24 @@ class ProfileManager:
 
         for var in list(os.environ.keys()):
             if var.startswith("ZOWE_OPT"):
-                env[var[len("ZOWE_OPT_"):].lower()] = os.environ.get(var)
+                env[var[len("ZOWE_OPT_") :].lower()] = os.environ.get(var)
 
         for k, v in env.items():
             word = k.split("_")
 
             if len(word) > 1:
-                k = word[0]+word[1].capitalize()
+                k = word[0] + word[1].capitalize()
             else:
                 k = word[0]
 
             if k in list(props.keys()):
-                if props[k]['type'] == "number":
+                if props[k]["type"] == "number":
                     env_var[k] = int(v)
 
-                elif props[k]['type'] == "string":
+                elif props[k]["type"] == "string":
                     env_var[k] = str(v)
 
-                elif props[k]['type'] == "boolean":
+                elif props[k]["type"] == "boolean":
                     env_var[k] = bool(v)
 
         return env_var
@@ -187,21 +184,15 @@ class ProfileManager:
                 f"Instance was invalid under the provided $schema property, {exc}"
             )
         except jsonschema.exceptions.SchemaError as exc:
-            raise jsonschema.exceptions.SchemaError(
-                f"The provided schema is invalid, {exc}"
-            )
+            raise jsonschema.exceptions.SchemaError(f"The provided schema is invalid, {exc}")
         except jsonschema.exceptions.UndefinedTypeCheck as exc:
             raise jsonschema.exceptions.UndefinedTypeCheck(
                 f"A type checker was asked to check a type it did not have registered, {exc}"
             )
         except jsonschema.exceptions.UnknownType as exc:
-            raise jsonschema.exceptions.UnknownType(
-                f"Unknown type is found in schema_json, exc"
-            )
+            raise jsonschema.exceptions.UnknownType(f"Unknown type is found in schema_json, exc")
         except jsonschema.exceptions.FormatError as exc:
-            raise jsonschema.exceptions.FormatError(
-                f"Validating a format config_json failed for schema_json, {exc}"
-            )
+            raise jsonschema.exceptions.FormatError(f"Validating a format config_json failed for schema_json, {exc}")
         except ProfileNotFound:
             if profile_name:
                 warnings.warn(
@@ -216,8 +207,7 @@ class ProfileManager:
                 )
         except Exception as exc:
             warnings.warn(
-                f"Could not load '{cfg.filename}' at '{cfg.filepath}'"
-                f"because {type(exc).__name__}'{exc}'.",
+                f"Could not load '{cfg.filename}' at '{cfg.filepath}'" f"because {type(exc).__name__}'{exc}'.",
                 ConfigNotFoundWarning,
             )
 
@@ -296,7 +286,13 @@ class ProfileManager:
             if name not in profiles_merged:
                 profiles_merged[name] = value
 
-        cfg = ConfigFile(type="Merged Config", name=cfg_name, profiles=profiles_merged, defaults=defaults_merged, schema_property=cfg_schema)
+        cfg = ConfigFile(
+            type="Merged Config",
+            name=cfg_name,
+            profiles=profiles_merged,
+            defaults=defaults_merged,
+            schema_property=cfg_schema,
+        )
         profile_loaded = self.get_profile(cfg, profile_name, profile_type, validate_schema)
         if profile_loaded:
             profile_props = profile_loaded.data
@@ -341,12 +337,7 @@ class ProfileManager:
         """
         highest_layer = None
         longest_match = ""
-        layers = [
-            self.project_user_config,
-            self.project_config,
-            self.global_user_config,
-            self.global_config
-        ]
+        layers = [self.project_user_config, self.project_config, self.global_user_config, self.global_config]
 
         original_name = layers[0].get_profile_name_from_path(json_path)
 
@@ -378,7 +369,6 @@ class ProfileManager:
             raise FileNotFoundError(f"Could not find a valid layer for {json_path}")
 
         return highest_layer
-
 
     def set_property(self, json_path, value, secure=None) -> None:
         """
@@ -413,10 +403,7 @@ class ProfileManager:
         """
         Save the layers (configuration files) to disk.
         """
-        layers = [self.project_user_config,
-                  self.project_config,
-                  self.global_user_config,
-                  self.global_config]
+        layers = [self.project_user_config, self.project_config, self.global_user_config, self.global_config]
 
         for layer in layers:
             layer.save(False)

--- a/src/core/zowe/core_for_zowe_sdk/profile_manager.py
+++ b/src/core/zowe/core_for_zowe_sdk/profile_manager.py
@@ -38,8 +38,8 @@ HAS_KEYRING = True
 
 
 HOME = os.path.expanduser("~")
-GLOBAl_CONFIG_LOCATION = os.path.join(HOME, ".zowe")
-GLOBAL_CONFIG_PATH = os.path.join(GLOBAl_CONFIG_LOCATION, f"{GLOBAL_CONFIG_NAME}.config.json")
+GLOBAL_CONFIG_LOCATION = os.path.join(HOME, ".zowe")
+GLOBAL_CONFIG_PATH = os.path.join(GLOBAL_CONFIG_LOCATION, f"{GLOBAL_CONFIG_NAME}.config.json")
 CURRENT_DIR = os.getcwd()
 
 
@@ -59,7 +59,7 @@ class ProfileManager:
 
         self.global_config = ConfigFile(type=TEAM_CONFIG, name=GLOBAL_CONFIG_NAME)
         try:
-            self.global_config.location = GLOBAl_CONFIG_LOCATION
+            self.global_config.location = GLOBAL_CONFIG_LOCATION
         except Exception:
             warnings.warn(
                 "Could not find Global Config Directory, please provide one.",
@@ -68,7 +68,7 @@ class ProfileManager:
 
         self.global_user_config = ConfigFile(type=USER_CONFIG, name=GLOBAL_CONFIG_NAME)
         try:
-            self.global_user_config.location = GLOBAl_CONFIG_LOCATION
+            self.global_user_config.location = GLOBAL_CONFIG_LOCATION
         except Exception:
             warnings.warn(
                 "Could not find Global User Config Directory, please provide one.",

--- a/src/core/zowe/core_for_zowe_sdk/request_handler.py
+++ b/src/core/zowe/core_for_zowe_sdk/request_handler.py
@@ -10,11 +10,10 @@ SPDX-License-Identifier: EPL-2.0
 Copyright Contributors to the Zowe Project.
 """
 
-from .exceptions import UnexpectedStatus
-from .exceptions import RequestFailed
-from .exceptions import InvalidRequestMethod
 import requests
 import urllib3
+
+from .exceptions import InvalidRequestMethod, RequestFailed, UnexpectedStatus
 
 
 class RequestHandler:
@@ -44,7 +43,7 @@ class RequestHandler:
 
     def __handle_ssl_warnings(self):
         """Turn off warnings if the SSL verification argument if off."""
-        if not self.session_arguments['verify']:
+        if not self.session_arguments["verify"]:
             urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
     def perform_request(self, method, request_arguments, expected_code=[200]):
@@ -142,8 +141,8 @@ class RequestHandler:
         -------
         A bytes object if the response content type is application/octet-stream,
         a normalized JSON for the request response otherwise
-        """  
-        if self.response.headers.get('Content-Type') == 'application/octet-stream':
+        """
+        if self.response.headers.get("Content-Type") == "application/octet-stream":
             return self.response.content
         else:
             try:

--- a/src/core/zowe/core_for_zowe_sdk/sdk_api.py
+++ b/src/core/zowe/core_for_zowe_sdk/sdk_api.py
@@ -11,10 +11,11 @@ Copyright Contributors to the Zowe Project.
 """
 
 import urllib
+
+from . import session_constants
 from .exceptions import UnsupportedAuthType
 from .request_handler import RequestHandler
-from .session import Session, ISession
-from . import session_constants
+from .session import ISession, Session
 
 
 class SdkApi:
@@ -22,7 +23,7 @@ class SdkApi:
     Abstract class used to represent the base SDK API.
     """
 
-    def __init__(self, profile, default_url):  
+    def __init__(self, profile, default_url):
         self.profile = profile
         session = Session(profile)
         self.session: ISession = session.load()

--- a/src/core/zowe/core_for_zowe_sdk/session.py
+++ b/src/core/zowe/core_for_zowe_sdk/session.py
@@ -67,9 +67,7 @@ class Session:
         self.session.basePath = props.get("basePath")
         self.session.port = props.get("port", self.session.port)
         self.session.protocol = props.get("protocol", self.session.protocol)
-        self.session.rejectUnauthorized = props.get(
-            "rejectUnauthorized", self.session.rejectUnauthorized
-        )
+        self.session.rejectUnauthorized = props.get("rejectUnauthorized", self.session.rejectUnauthorized)
 
     def load(self) -> ISession:
         return self.session

--- a/src/core/zowe/core_for_zowe_sdk/validators.py
+++ b/src/core/zowe/core_for_zowe_sdk/validators.py
@@ -10,11 +10,12 @@ SPDX-License-Identifier: EPL-2.0
 Copyright Contributors to the Zowe Project.
 """
 
-import commentjson
-from jsonschema import validate
 import os
-from typing import Union, Optional
+from typing import Optional, Union
+
+import commentjson
 import requests
+from jsonschema import validate
 
 
 def validate_config_json(path_config_json: Union[str, dict], path_schema_json: str, cwd: str):
@@ -50,7 +51,7 @@ def validate_config_json(path_config_json: Union[str, dict], path_schema_json: s
             schema_json = commentjson.load(file)
 
     # if there is no path_schema_json it will return None
-    else: 
+    else:
         return None
 
     if isinstance(path_config_json, str):

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,10 +1,13 @@
 import os.path
 import uuid
+
 from setuptools import setup
+
 from _version import __version__
 
 src_dir = os.path.realpath(os.path.dirname(__file__))
 uuid4 = uuid.uuid4()
+
 
 def resolve_sdk_dep(sdk_name, version_spec):
     # if os.path.exists(os.path.join(src_dir, sdk_name, "zowe")):
@@ -15,11 +18,12 @@ def resolve_sdk_dep(sdk_name, version_spec):
     # else:
     return f"zowe.{sdk_name}_for_zowe_sdk{version_spec}"
 
+
 if __name__ == "__main__":
     setup(
-        name='zowe',
+        name="zowe",
         version=__version__,
-        description='Zowe Python SDK',
+        description="Zowe Python SDK",
         url="https://github.com/zowe/zowe-client-python-sdk",
         author="Guilherme Cartier",
         author_email="gcartier94@gmail.com",
@@ -27,11 +31,14 @@ if __name__ == "__main__":
         classifiers=[
             "Programming Language :: Python :: 3",
             "Programming Language :: Python :: 3.7",
-            "License :: OSI Approved :: Eclipse Public License 2.0 (EPL-2.0)"],
-        install_requires=[resolve_sdk_dep('zos_console', '==' + __version__),
-                        resolve_sdk_dep('zos_files', '==' + __version__),
-                        resolve_sdk_dep('zos_tso', '==' + __version__),
-                        resolve_sdk_dep('zos_jobs', '==' + __version__),
-                        resolve_sdk_dep('zosmf', '==' + __version__)],
-        py_modules=[]
+            "License :: OSI Approved :: Eclipse Public License 2.0 (EPL-2.0)",
+        ],
+        install_requires=[
+            resolve_sdk_dep("zos_console", "==" + __version__),
+            resolve_sdk_dep("zos_files", "==" + __version__),
+            resolve_sdk_dep("zos_tso", "==" + __version__),
+            resolve_sdk_dep("zos_jobs", "==" + __version__),
+            resolve_sdk_dep("zosmf", "==" + __version__),
+        ],
+        py_modules=[],
     )

--- a/src/zos_console/setup.py
+++ b/src/zos_console/setup.py
@@ -1,13 +1,15 @@
 import sys
-from setuptools import setup, find_namespace_packages
+
+from setuptools import find_namespace_packages, setup
+
 sys.path.insert(0, "..")
 from _version import __version__
 from setup import resolve_sdk_dep
 
 setup(
-    name='zowe_zos_console_for_zowe_sdk',
+    name="zowe_zos_console_for_zowe_sdk",
     version=__version__,
-    description='Zowe Python SDK - z/OS Console package',
+    description="Zowe Python SDK - z/OS Console package",
     url="https://github.com/zowe/zowe-client-python-sdk",
     author="Guilherme Cartier",
     author_email="gcartier94@gmail.com",
@@ -15,7 +17,8 @@ setup(
     classifiers=[
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.7",
-        "License :: OSI Approved :: Eclipse Public License 2.0 (EPL-2.0)"],
-    install_requires=[resolve_sdk_dep('core', '~=' + __version__)],
-    packages=find_namespace_packages(include=['zowe.*'])
+        "License :: OSI Approved :: Eclipse Public License 2.0 (EPL-2.0)",
+    ],
+    install_requires=[resolve_sdk_dep("core", "~=" + __version__)],
+    packages=find_namespace_packages(include=["zowe.*"]),
 )

--- a/src/zos_console/zowe/zos_console_for_zowe_sdk/console.py
+++ b/src/zos_console/zowe/zos_console_for_zowe_sdk/console.py
@@ -1,5 +1,6 @@
 from zowe.core_for_zowe_sdk import SdkApi
 
+
 class Console(SdkApi):
     """
     Class used to represent the base z/OSMF Console API.
@@ -47,7 +48,7 @@ class Console(SdkApi):
     def get_response(self, response_key, console=None):
         """
         Collect outstanding synchronous z/OS Console response messages.
-        
+
         Parameters
         ----------
         response_key

--- a/src/zos_files/setup.py
+++ b/src/zos_files/setup.py
@@ -1,13 +1,15 @@
 import sys
-from setuptools import setup, find_namespace_packages
+
+from setuptools import find_namespace_packages, setup
+
 sys.path.insert(0, "..")
 from _version import __version__
 from setup import resolve_sdk_dep
 
 setup(
-    name='zowe_zos_files_for_zowe_sdk',
+    name="zowe_zos_files_for_zowe_sdk",
     version=__version__,
-    description='Zowe Python SDK - z/OS Files package',
+    description="Zowe Python SDK - z/OS Files package",
     url="https://github.com/zowe/zowe-client-python-sdk",
     author="Guilherme Cartier",
     author_email="gcartier94@gmail.com",
@@ -15,7 +17,8 @@ setup(
     classifiers=[
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.7",
-        "License :: OSI Approved :: Eclipse Public License 2.0 (EPL-2.0)"],
-    install_requires=[resolve_sdk_dep('core', '~=' + __version__)],
-    packages=find_namespace_packages(include=['zowe.*'])
+        "License :: OSI Approved :: Eclipse Public License 2.0 (EPL-2.0)",
+    ],
+    install_requires=[resolve_sdk_dep("core", "~=" + __version__)],
+    packages=find_namespace_packages(include=["zowe.*"]),
 )

--- a/src/zos_files/zowe/zos_files_for_zowe_sdk/__init__.py
+++ b/src/zos_files/zowe/zos_files_for_zowe_sdk/__init__.py
@@ -2,5 +2,5 @@
 Zowe Python SDK - z/OS Files package
 """
 
+from . import constants, exceptions
 from .files import Files
-from . import exceptions, constants

--- a/src/zos_files/zowe/zos_files_for_zowe_sdk/constants.py
+++ b/src/zos_files/zowe/zos_files_for_zowe_sdk/constants.py
@@ -14,8 +14,9 @@ zos_file_constants = {
     "MaxAllocationQuantity": 16777215,
 }
 from enum import Enum
+
+
 class FileType(Enum):
     BINARY = "binary"
     EXECUTABLE = "executable"
     TEXT = "text"
-    

--- a/src/zos_files/zowe/zos_files_for_zowe_sdk/exceptions.py
+++ b/src/zos_files/zowe/zos_files_for_zowe_sdk/exceptions.py
@@ -30,4 +30,6 @@ class MaxAllocationQuantityExceeded(Exception):
     """Class used to represent an invalid allocation quantity."""
 
     def __init__(self):
-        super().__init__("Maximum allocation quantity of {} exceeded".format(zos_file_constants['MaxAllocationQuantity']))
+        super().__init__(
+            "Maximum allocation quantity of {} exceeded".format(zos_file_constants["MaxAllocationQuantity"])
+        )

--- a/src/zos_jobs/setup.py
+++ b/src/zos_jobs/setup.py
@@ -1,13 +1,15 @@
 import sys
-from setuptools import setup, find_namespace_packages
+
+from setuptools import find_namespace_packages, setup
+
 sys.path.insert(0, "..")
 from _version import __version__
 from setup import resolve_sdk_dep
 
 setup(
-    name='zowe_zos_jobs_for_zowe_sdk',
+    name="zowe_zos_jobs_for_zowe_sdk",
     version=__version__,
-    description='Zowe Python SDK - z/OS Jobs package',
+    description="Zowe Python SDK - z/OS Jobs package",
     url="https://github.com/zowe/zowe-client-python-sdk",
     author="Guilherme Cartier",
     author_email="gcartier94@gmail.com",
@@ -15,7 +17,8 @@ setup(
     classifiers=[
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.7",
-        "License :: OSI Approved :: Eclipse Public License 2.0 (EPL-2.0)"],
-    install_requires=[resolve_sdk_dep('core', '~=' + __version__)],
-    packages=find_namespace_packages(include=['zowe.*'])
+        "License :: OSI Approved :: Eclipse Public License 2.0 (EPL-2.0)",
+    ],
+    install_requires=[resolve_sdk_dep("core", "~=" + __version__)],
+    packages=find_namespace_packages(include=["zowe.*"]),
 )

--- a/src/zos_jobs/zowe/zos_jobs_for_zowe_sdk/jobs.py
+++ b/src/zos_jobs/zowe/zos_jobs_for_zowe_sdk/jobs.py
@@ -9,8 +9,9 @@ SPDX-License-Identifier: EPL-2.0
 
 Copyright Contributors to the Zowe Project.
 """
-from zowe.core_for_zowe_sdk import SdkApi
 import os
+
+from zowe.core_for_zowe_sdk import SdkApi
 
 
 class Jobs(SdkApi):
@@ -80,10 +81,7 @@ class Jobs(SdkApi):
         job_url = "{}/{}".format(jobname, jobid)
         request_url = "{}{}".format(self.request_endpoint, self._encode_uri_component(job_url))
         custom_args["url"] = request_url
-        custom_args["json"] = {
-            "request": "cancel",
-            "version": modify_version
-        }
+        custom_args["json"] = {"request": "cancel", "version": modify_version}
 
         response_json = self.request_handler.perform_request("PUT", custom_args, expected_code=[202, 200])
         return response_json
@@ -118,21 +116,17 @@ class Jobs(SdkApi):
         return response_json
 
     def _issue_job_request(self, req: dict, jobname: str, jobid: str, modify_version):
-
         custom_args = self._create_custom_request_arguments()
         job_url = "{}/{}".format(jobname, jobid)
         request_url = "{}{}".format(self.request_endpoint, self._encode_uri_component(job_url))
         custom_args["url"] = request_url
-        custom_args["json"] = {
-            **req,
-            "version": modify_version 
-        }
+        custom_args["json"] = {**req, "version": modify_version}
 
         custom_args["headers"]["X-IBM-Job-Modify-Version"] = modify_version
-            
+
         response_json = self.request_handler.perform_request("PUT", custom_args, expected_code=[202, 200])
         return response_json
-       
+
     def change_job_class(self, jobname: str, jobid: str, class_name: str, modify_version="2.0"):
         """Changes the job class
 
@@ -158,7 +152,7 @@ class Jobs(SdkApi):
 
     def hold_job(self, jobname: str, jobid: str, modify_version="2.0"):
         """Hold the given job on JES
-        
+
         Parameters
         ----------
         jobname: str
@@ -175,13 +169,13 @@ class Jobs(SdkApi):
         """
         if modify_version not in ("1.0", "2.0"):
             raise ValueError('Accepted values for modify_version: "1.0" or "2.0"')
-        
+
         response_json = self._issue_job_request({"request": "hold"}, jobname, jobid, modify_version)
         return response_json
 
     def release_job(self, jobname: str, jobid: str, modify_version="2.0"):
         """Release the given job on JES
-        
+
         Parameters
         ----------
         jobname: str
@@ -198,11 +192,11 @@ class Jobs(SdkApi):
         """
         if modify_version not in ("1.0", "2.0"):
             raise ValueError('Accepted values for modify_version: "1.0" or "2.0"')
-        
+
         response_json = self._issue_job_request({"request": "release"}, jobname, jobid, modify_version)
         return response_json
 
-    def list_jobs(self, owner=None,  prefix="*", max_jobs=1000, user_correlator=None):
+    def list_jobs(self, owner=None, prefix="*", max_jobs=1000, user_correlator=None):
         """Retrieve list of jobs on JES based on the provided arguments.
 
         Parameters
@@ -244,11 +238,9 @@ class Jobs(SdkApi):
             A JSON containing the result of the request execution
         """
         custom_args = self._create_custom_request_arguments()
-        request_body = {"file": "//\'%s\'" % jcl_path}
+        request_body = {"file": "//'%s'" % jcl_path}
         custom_args["json"] = request_body
-        response_json = self.request_handler.perform_request(
-            "PUT", custom_args, expected_code=[201]
-        )
+        response_json = self.request_handler.perform_request("PUT", custom_args, expected_code=[201])
         return response_json
 
     def submit_from_local_file(self, jcl_path):
@@ -297,9 +289,7 @@ class Jobs(SdkApi):
         custom_args = self._create_custom_request_arguments()
         custom_args["data"] = str(jcl)
         custom_args["headers"] = {"Content-Type": "text/plain", "X-CSRF-ZOSMF-HEADER": ""}
-        response_json = self.request_handler.perform_request(
-            "PUT", custom_args, expected_code=[201]
-        )
+        response_json = self.request_handler.perform_request("PUT", custom_args, expected_code=[201])
         return response_json
 
     def get_spool_files(self, correlator):
@@ -321,7 +311,7 @@ class Jobs(SdkApi):
         custom_args["url"] = request_url
         response_json = self.request_handler.perform_request("GET", custom_args)
         return response_json
-        
+
     def get_jcl_text(self, correlator):
         """Retrieve the input JCL text for job with specified correlator
         Parameters
@@ -339,7 +329,7 @@ class Jobs(SdkApi):
         request_url = "{}{}".format(self.request_endpoint, self._encode_uri_component(job_url))
         custom_args["url"] = request_url
         response_json = self.request_handler.perform_request("GET", custom_args)
-        return response_json        
+        return response_json
 
     def get_spool_file_contents(self, correlator, id):
         """Retrieve the contents of a single spool file from a job
@@ -380,7 +370,7 @@ class Jobs(SdkApi):
                         dir: stepname
                             |
                             file: spool file <nn>
-                            ...         
+                            ...
 
 
         Parameters
@@ -397,31 +387,31 @@ class Jobs(SdkApi):
             A JSON containing the result of the request execution
         """
 
-        _job_name   = status['jobname']
-        _job_id     = status['jobid']
-        _job_correlator = status['job-correlator']
+        _job_name = status["jobname"]
+        _job_id = status["jobid"]
+        _job_correlator = status["job-correlator"]
 
         _output_dir = os.path.join(output_dir, _job_name, _job_id)
         os.makedirs(_output_dir, exist_ok=True)
-        _output_file = os.path.join(output_dir, _job_name, _job_id, 'jcl.txt')
+        _output_file = os.path.join(output_dir, _job_name, _job_id, "jcl.txt")
         _data_spool_file = self.get_jcl_text(_job_correlator)
-        _dataset_content = _data_spool_file['response']
-        _out_file = open(_output_file, 'w')
+        _dataset_content = _data_spool_file["response"]
+        _out_file = open(_output_file, "w")
         _out_file.write(_dataset_content)
         _out_file.close()
 
         _spool = self.get_spool_files(_job_correlator)
         for _spool_file in _spool:
-            _stepname = _spool_file['stepname']
-            _ddname = _spool_file['ddname']
-            _spoolfile_id = _spool_file['id']
+            _stepname = _spool_file["stepname"]
+            _ddname = _spool_file["ddname"]
+            _spoolfile_id = _spool_file["id"]
             _output_dir = os.path.join(output_dir, _job_name, _job_id, _stepname)
             os.makedirs(_output_dir, exist_ok=True)
-        
+
             _output_file = os.path.join(output_dir, _job_name, _job_id, _stepname, _ddname)
             _data_spool_file = self.get_spool_file_contents(_job_correlator, _spoolfile_id)
-            _dataset_content = _data_spool_file['response']
-            _out_file = open(_output_file, 'w')
+            _dataset_content = _data_spool_file["response"]
+            _out_file = open(_output_file, "w")
             _out_file.write(_dataset_content)
             _out_file.close()
 

--- a/src/zos_tso/setup.py
+++ b/src/zos_tso/setup.py
@@ -1,13 +1,15 @@
 import sys
-from setuptools import setup, find_namespace_packages
+
+from setuptools import find_namespace_packages, setup
+
 sys.path.insert(0, "..")
 from _version import __version__
 from setup import resolve_sdk_dep
 
 setup(
-    name='zowe_zos_tso_for_zowe_sdk',
+    name="zowe_zos_tso_for_zowe_sdk",
     version=__version__,
-    description='Zowe Python SDK - z/OS TSO package',
+    description="Zowe Python SDK - z/OS TSO package",
     url="https://github.com/zowe/zowe-client-python-sdk",
     author="Guilherme Cartier",
     author_email="gcartier94@gmail.com",
@@ -15,7 +17,8 @@ setup(
     classifiers=[
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.7",
-        "License :: OSI Approved :: Eclipse Public License 2.0 (EPL-2.0)"],
-    install_requires=[resolve_sdk_dep('core', '~=' + __version__)],
-    packages=find_namespace_packages(include=['zowe.*'])
+        "License :: OSI Approved :: Eclipse Public License 2.0 (EPL-2.0)",
+    ],
+    install_requires=[resolve_sdk_dep("core", "~=" + __version__)],
+    packages=find_namespace_packages(include=["zowe.*"]),
 )

--- a/src/zos_tso/zowe/zos_tso_for_zowe_sdk/tso.py
+++ b/src/zos_tso/zowe/zos_tso_for_zowe_sdk/tso.py
@@ -125,7 +125,7 @@ class Tso(SdkApi):
         """
         custom_args = self._create_custom_request_arguments()
         custom_args["url"] = "{}/{}".format(self.request_endpoint, str(session_key))
-        custom_args["json"] = {"TSO RESPONSE":{"VERSION":"0100","DATA":str(message)}}
+        custom_args["json"] = {"TSO RESPONSE": {"VERSION": "0100", "DATA": str(message)}}
         response_json = self.request_handler.perform_request("PUT", custom_args)
         return response_json["tsoData"]
 
@@ -144,16 +144,10 @@ class Tso(SdkApi):
             Where the options are: 'Ping successful' or 'Ping failed'
         """
         custom_args = self._create_custom_request_arguments()
-        custom_args["url"] = "{}/{}/{}".format(
-            self.request_endpoint, "ping", str(session_key)
-        )
+        custom_args["url"] = "{}/{}/{}".format(self.request_endpoint, "ping", str(session_key))
         response_json = self.request_handler.perform_request("PUT", custom_args)
         message_id_list = self.parse_message_ids(response_json)
-        return (
-            "Ping successful"
-            if self.session_not_found not in message_id_list
-            else "Ping failed"
-        )
+        return "Ping successful" if self.session_not_found not in message_id_list else "Ping failed"
 
     def end_tso_session(self, session_key):
         """Terminates an existing TSO session.
@@ -172,11 +166,7 @@ class Tso(SdkApi):
         custom_args["url"] = "{}/{}".format(self.request_endpoint, session_key)
         response_json = self.request_handler.perform_request("DELETE", custom_args)
         message_id_list = self.parse_message_ids(response_json)
-        return (
-            "Session ended"
-            if self.session_not_found not in message_id_list
-            else "Session already ended"
-        )
+        return "Session ended" if self.session_not_found not in message_id_list else "Session already ended"
 
     def parse_message_ids(self, response_json):
         """Parse TSO response and retrieve only the message ids.
@@ -191,11 +181,7 @@ class Tso(SdkApi):
         list
             A list containing the TSO response message ids
         """
-        return (
-            [message["messageId"] for message in response_json["msgData"]]
-            if "msgData" in response_json
-            else []
-        )
+        return [message["messageId"] for message in response_json["msgData"]] if "msgData" in response_json else []
 
     def retrieve_tso_messages(self, response_json):
         """Parse the TSO response and retrieve all messages.
@@ -210,8 +196,4 @@ class Tso(SdkApi):
         list
             A list containing the TSO response messages
         """
-        return [
-            message["TSO MESSAGE"]["DATA"]
-            for message in response_json
-            if "TSO MESSAGE" in message
-        ]
+        return [message["TSO MESSAGE"]["DATA"] for message in response_json if "TSO MESSAGE" in message]

--- a/src/zosmf/setup.py
+++ b/src/zosmf/setup.py
@@ -1,13 +1,15 @@
 import sys
-from setuptools import setup, find_namespace_packages
+
+from setuptools import find_namespace_packages, setup
+
 sys.path.insert(0, "..")
 from _version import __version__
 from setup import resolve_sdk_dep
 
 setup(
-    name='zowe_zosmf_for_zowe_sdk',
+    name="zowe_zosmf_for_zowe_sdk",
     version=__version__,
-    description='Zowe Python SDK - z/OSMF package',
+    description="Zowe Python SDK - z/OSMF package",
     url="https://github.com/zowe/zowe-client-python-sdk",
     author="Guilherme Cartier",
     author_email="gcartier94@gmail.com",
@@ -15,7 +17,8 @@ setup(
     classifiers=[
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.7",
-        "License :: OSI Approved :: Eclipse Public License 2.0 (EPL-2.0)"],
-    install_requires=[resolve_sdk_dep('core', '~=' + __version__)],
-    packages=find_namespace_packages(include=['zowe.*'])
+        "License :: OSI Approved :: Eclipse Public License 2.0 (EPL-2.0)",
+    ],
+    install_requires=[resolve_sdk_dep("core", "~=" + __version__)],
+    packages=find_namespace_packages(include=["zowe.*"]),
 )

--- a/src/zosmf/zowe/zosmf_for_zowe_sdk/zosmf.py
+++ b/src/zosmf/zowe/zosmf_for_zowe_sdk/zosmf.py
@@ -41,9 +41,7 @@ class Zosmf(SdkApi):
         json
             A JSON containing the z/OSMF Info REST API data
         """
-        response_json = self.request_handler.perform_request(
-            "GET", self.request_arguments
-        )
+        response_json = self.request_handler.perform_request("GET", self.request_arguments)
         return response_json
 
     def list_systems(self):
@@ -56,5 +54,5 @@ class Zosmf(SdkApi):
 
         custom_args = self._create_custom_request_arguments()
         custom_args["url"] = "{}/systems".format(self.request_endpoint)
-        response_json = self.request_handler.perform_request("GET", custom_args, expected_code = [200])
+        response_json = self.request_handler.perform_request("GET", custom_args, expected_code=[200])
         return response_json

--- a/tests/integration/test_zos_console.py
+++ b/tests/integration/test_zos_console.py
@@ -1,7 +1,8 @@
 """Integration tests for the Zowe Python SDK z/OS Console package."""
 import unittest
-from zowe.zos_console_for_zowe_sdk import Console
+
 from zowe.core_for_zowe_sdk import ProfileManager
+from zowe.zos_console_for_zowe_sdk import Console
 
 
 class TestConsoleIntegration(unittest.TestCase):
@@ -11,15 +12,14 @@ class TestConsoleIntegration(unittest.TestCase):
         """Setup fixtures for Console class."""
         test_profile = ProfileManager().load(profile_type="zosmf")
         self.console = Console(test_profile)
-    
+
     def test_console_command_time_should_return_time(self):
         """Test the execution of the time command should return the current time"""
         command_output = self.console.issue_command("D T")
-        self.assertTrue(command_output['cmd-response'].strip().startswith("IEE136I"))
+        self.assertTrue(command_output["cmd-response"].strip().startswith("IEE136I"))
 
     def test_get_response_should_return_messages(self):
         """Test that response message can be received from the console"""
         command_output = self.console.issue_command("D T")
         response = self.console.get_response(command_output["cmd-response-key"])
         self.assertTrue("cmd-response" in response)
-

--- a/tests/integration/test_zos_files.py
+++ b/tests/integration/test_zos_files.py
@@ -1,13 +1,14 @@
 """Integration tests for the Zowe Python SDK z/OS Files package."""
-import unittest
 import json
 import os
-from zowe.zos_files_for_zowe_sdk import Files
+import unittest
+
 import urllib3
 from zowe.core_for_zowe_sdk import ProfileManager
+from zowe.zos_files_for_zowe_sdk import Files
 
-FIXTURES_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)),'fixtures')
-FILES_FIXTURES_PATH = os.path.join(FIXTURES_PATH, 'files.json')
+FIXTURES_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fixtures")
+FILES_FIXTURES_PATH = os.path.join(FIXTURES_PATH, "files.json")
 
 
 class TestFilesIntegration(unittest.TestCase):
@@ -17,44 +18,43 @@ class TestFilesIntegration(unittest.TestCase):
         """Setup fixtures for Files class."""
         test_profile = ProfileManager().load(profile_type="zosmf")
         self.user_name = test_profile["user"]
-        with open(FILES_FIXTURES_PATH, 'r') as fixtures_json:
+        with open(FILES_FIXTURES_PATH, "r") as fixtures_json:
             self.files_fixtures = json.load(fixtures_json)
         self.files = Files(test_profile)
         self.test_member_jcl = f'{self.files_fixtures["TEST_PDS"]}({self.files_fixtures["TEST_MEMBER"]})'
         self.test_member_generic = f'{self.files_fixtures["TEST_PDS"]}(TEST)'
         self.test1_zfs_file_system = f'{self.user_name}.{self.files_fixtures["TEST1_ZFS"]}'
         self.test2_zfs_file_system = f'{self.user_name}.{self.files_fixtures["TEST2_ZFS"]}'
-        self.create_zfs_options = {"perms": 755,"cylsPri": 10,"cylsSec": 2,"timeout": 20, "volumes": ["VPMVSC"]}
+        self.create_zfs_options = {"perms": 755, "cylsPri": 10, "cylsSec": 2, "timeout": 20, "volumes": ["VPMVSC"]}
         self.mount_zfs_file_system_options = {"fs-type": "ZFS", "mode": "rdonly"}
 
     def test_list_dsn_should_return_a_list_of_datasets(self):
         """Executing list_dsn method should return a list of found datasets."""
-        
+
         scenarios = [
             {"attributes": False, "expected_attributes": ["dsname"]},
-            {"attributes": True, "expected_attributes": ["dsname", "migr","vol"]}
+            {"attributes": True, "expected_attributes": ["dsname", "migr", "vol"]},
         ]
-        
-        for scenario in scenarios:
 
+        for scenario in scenarios:
             # Get the command output
             command_output = self.files.list_dsn(self.files_fixtures["TEST_HLQ"], scenario["attributes"])
-            
+
             # Assert that command_output['items'] is a list
-            self.assertIsInstance(command_output['items'], list)
-            
+            self.assertIsInstance(command_output["items"], list)
+
             # Assert that command_output['items'] contains at least one item
-            self.assertGreater(len(command_output['items']), 0)
-            
+            self.assertGreater(len(command_output["items"]), 0)
+
             # Assert that the first item in the list has 'dsname' defined
-            first_item = command_output['items'][0]
-            self.assertIn('dsname', first_item)
-            
+            first_item = command_output["items"][0]
+            self.assertIn("dsname", first_item)
+
             # Assert that the first item in the list has the expected attributes defined
             attributes = first_item.keys()
             for expected_attr in scenario["expected_attributes"]:
                 self.assertIn(expected_attr, attributes)
-        
+
     def test_list_members_should_return_a_list_of_members(self):
         """Executing list_dsn_members should return a list of members."""
         command_output = self.files.list_dsn_members(self.files_fixtures["TEST_PDS"])
@@ -63,7 +63,7 @@ class TestFilesIntegration(unittest.TestCase):
     def test_get_dsn_content_should_return_content_from_dataset(self):
         """Executing get_dsn_content should return content from dataset."""
         command_output = self.files.get_dsn_content(self.test_member_jcl)
-        self.assertIsInstance(command_output['response'], str)
+        self.assertIsInstance(command_output["response"], str)
 
     def test_get_dsn_content_streamed_should_return_a_raw_response_content(self):
         """Executing get_dsn_content_streamed should return raw socket response from the server."""
@@ -78,49 +78,51 @@ class TestFilesIntegration(unittest.TestCase):
     def test_write_to_dsn_should_be_possible(self):
         """Executing write_to_dsn should be possible."""
         command_output = self.files.write_to_dsn(self.test_member_generic, "HELLO WORLD")
-        self.assertTrue(command_output['response'] == '')
-    
-    
+        self.assertTrue(command_output["response"] == "")
+
     def test_copy_uss_to_dataset_should_be_possible(self):
         """Executing copy_uss_to_dataset should be possible."""
-        command_output = self.files.copy_uss_to_dataset(self.files_fixtures["TEST_USS"],"ZOWE.TESTS.JCL(TEST2)",replace=True)
-        self.assertTrue(command_output['response']=="")
+        command_output = self.files.copy_uss_to_dataset(
+            self.files_fixtures["TEST_USS"], "ZOWE.TESTS.JCL(TEST2)", replace=True
+        )
+        self.assertTrue(command_output["response"] == "")
 
     def test_copy_dataset_or_member_should_be_possible(self):
         """Executing copy_dataset_or_member should be possible."""
         test_case = {
-        "from_dataset_name": self.files_fixtures["TEST_PDS"],
-        "to_dataset_name": self.files_fixtures["TEST_PDS"],
-        "from_member_name": self.files_fixtures["TEST_MEMBER"],
-        "to_member_name": "TEST",
-        "replace": True
+            "from_dataset_name": self.files_fixtures["TEST_PDS"],
+            "to_dataset_name": self.files_fixtures["TEST_PDS"],
+            "from_member_name": self.files_fixtures["TEST_MEMBER"],
+            "to_member_name": "TEST",
+            "replace": True,
         }
         command_output = self.files.copy_dataset_or_member(**test_case)
-        self.assertTrue(command_output['response'] =="")
+        self.assertTrue(command_output["response"] == "")
 
     def test_mount_unmount_zfs_file_system(self):
         """Mounting a zfs filesystem should be possible"""
         username = self.user_name.lower()
-        mount_point = f"/u/{username}/mount" # Assuming a dir called mount exist in zOS USS
+        mount_point = f"/u/{username}/mount"  # Assuming a dir called mount exist in zOS USS
 
         # Create a zfs file system
         zfs_file_system = self.files.create_zFS_file_system(self.test2_zfs_file_system, self.create_zfs_options)
 
-
         # Mount file system
-        command_output = self.files.mount_file_system(self.test2_zfs_file_system, mount_point, self.mount_zfs_file_system_options)
-        self.assertTrue(command_output['response'] == '')
+        command_output = self.files.mount_file_system(
+            self.test2_zfs_file_system, mount_point, self.mount_zfs_file_system_options
+        )
+        self.assertTrue(command_output["response"] == "")
 
         # List a zfs file system
         command_output = self.files.list_unix_file_systems(file_system_name=self.test2_zfs_file_system)
-        self.assertTrue(len(command_output['items']) > 0)
+        self.assertTrue(len(command_output["items"]) > 0)
 
         # Unmount file system
         command_output = self.files.unmount_file_system(self.test2_zfs_file_system)
-        self.assertTrue(command_output['response'] == '')
+        self.assertTrue(command_output["response"] == "")
 
         # Delete file system
         command_output = self.files.delete_zFS_file_system(self.test2_zfs_file_system)
-        self.assertTrue(command_output['response'] == '')
+        self.assertTrue(command_output["response"] == "")
 
-    #TODO implement tests for download/upload datasets
+    # TODO implement tests for download/upload datasets

--- a/tests/integration/test_zos_jobs.py
+++ b/tests/integration/test_zos_jobs.py
@@ -1,13 +1,14 @@
 """Integration tests for the Zowe Python SDK z/OS Jobs package."""
-import unittest
 import json
 import os
-from zowe.zos_jobs_for_zowe_sdk import Jobs
-from zowe.core_for_zowe_sdk import ProfileManager
+import unittest
 
-FIXTURES_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)),'fixtures')
-JOBS_FIXTURES_JSON_JSON_PATH = os.path.join(FIXTURES_PATH, 'jobs.json')
-SAMPLE_JCL_FIXTURE_PATH = os.path.join(FIXTURES_PATH, 'sample.jcl')
+from zowe.core_for_zowe_sdk import ProfileManager
+from zowe.zos_jobs_for_zowe_sdk import Jobs
+
+FIXTURES_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fixtures")
+JOBS_FIXTURES_JSON_JSON_PATH = os.path.join(FIXTURES_PATH, "jobs.json")
+SAMPLE_JCL_FIXTURE_PATH = os.path.join(FIXTURES_PATH, "sample.jcl")
 
 
 class TestJobsIntegration(unittest.TestCase):
@@ -16,57 +17,57 @@ class TestJobsIntegration(unittest.TestCase):
     def setUp(self):
         """Setup fixtures for Jobs class."""
         test_profile = ProfileManager().load(profile_type="zosmf")
-        with open(JOBS_FIXTURES_JSON_JSON_PATH, 'r') as fixtures_json:
+        with open(JOBS_FIXTURES_JSON_JSON_PATH, "r") as fixtures_json:
             self.jobs_fixtures_json = json.load(fixtures_json)
         self.jobs = Jobs(test_profile)
 
     def test_get_job_status_should_return_the_status_of_a_job(self):
         """Executing the get_job_status method should return the status of a given job"""
-        execution_output = self.jobs.submit_from_mainframe(self.jobs_fixtures_json['TEST_JCL_MEMBER'])
-        jobname = execution_output['jobname']
-        jobid = execution_output['jobid']
+        execution_output = self.jobs.submit_from_mainframe(self.jobs_fixtures_json["TEST_JCL_MEMBER"])
+        jobname = execution_output["jobname"]
+        jobid = execution_output["jobid"]
         command_output = self.jobs.get_job_status(jobname, jobid)
-        self.assertIsNotNone(command_output['status'])
+        self.assertIsNotNone(command_output["status"])
 
     def test_list_jobs_should_return_valid_spool_information(self):
         """Executing the list_jobs method should return a list of found jobs in JES spool."""
-        command_output = self.jobs.list_jobs(owner=self.jobs_fixtures_json['TEST_JCL_OWNER'])
+        command_output = self.jobs.list_jobs(owner=self.jobs_fixtures_json["TEST_JCL_OWNER"])
         self.assertIsInstance(command_output, list)
-    
+
     def test_change_job_class(self):
         """Execute the change_jobs_class should execute successfully."""
-        execution_output = self.jobs.submit_from_mainframe(self.jobs_fixtures_json['TEST_JCL_MEMBER'])
-        jobname = execution_output['jobname']
-        jobid = execution_output['jobid']
-        classname = self.jobs_fixtures_json['TEST_JCL_CLASS']
+        execution_output = self.jobs.submit_from_mainframe(self.jobs_fixtures_json["TEST_JCL_MEMBER"])
+        jobname = execution_output["jobname"]
+        jobid = execution_output["jobid"]
+        classname = self.jobs_fixtures_json["TEST_JCL_CLASS"]
         command_output = self.jobs.change_job_class(jobname, jobid, classname)
         expected_class = self.jobs.get_job_status(jobname, jobid)
-        self.assertEqual(expected_class['class'], classname)
+        self.assertEqual(expected_class["class"], classname)
 
     def test_submit_hold_and_release_job_should_execute_properly(self):
         """Execute the hold_job should execute successfully."""
-        execution_output = self.jobs.submit_from_mainframe(self.jobs_fixtures_json['TEST_JCL_MEMBER'])
-        jobname = execution_output['jobname']
-        jobid = execution_output['jobid']
-        command_output = self.jobs.submit_from_mainframe(self.jobs_fixtures_json['TEST_JCL_MEMBER'])
+        execution_output = self.jobs.submit_from_mainframe(self.jobs_fixtures_json["TEST_JCL_MEMBER"])
+        jobname = execution_output["jobname"]
+        jobid = execution_output["jobid"]
+        command_output = self.jobs.submit_from_mainframe(self.jobs_fixtures_json["TEST_JCL_MEMBER"])
         command_output = self.jobs.hold_job(jobname, jobid)
         command_output = self.jobs.release_job(jobname, jobid)
-        self.assertIsNotNone(command_output['jobid'])
+        self.assertIsNotNone(command_output["jobid"])
 
     def test_submit_from_mainframe_should_execute_properly(self):
         """Executing the submit_from_mainframe method should execute successfully."""
-        command_output = self.jobs.submit_from_mainframe(self.jobs_fixtures_json['TEST_JCL_MEMBER'])
-        jobid = command_output['jobid']
+        command_output = self.jobs.submit_from_mainframe(self.jobs_fixtures_json["TEST_JCL_MEMBER"])
+        jobid = command_output["jobid"]
         self.assertIsNotNone(jobid)
 
     def test_submit_from_local_file_should_execute_properly(self):
         """Executing the submit_from_local_file method should execute successfully."""
         command_output = self.jobs.submit_from_local_file(SAMPLE_JCL_FIXTURE_PATH)
-        jobid = command_output['jobid']
+        jobid = command_output["jobid"]
         self.assertIsNotNone(jobid)
 
     def test_submit_plaintext_should_execute_properly(self):
         """Executing the submit_plaintext method should execute successfully."""
-        command_output = self.jobs.submit_plaintext('\n'.join(self.jobs_fixtures_json['TEST_JCL_CODE']))
-        jobid = command_output['jobid']
+        command_output = self.jobs.submit_plaintext("\n".join(self.jobs_fixtures_json["TEST_JCL_CODE"]))
+        jobid = command_output["jobid"]
         self.assertIsNotNone(jobid)

--- a/tests/integration/test_zos_tso.py
+++ b/tests/integration/test_zos_tso.py
@@ -1,7 +1,8 @@
 """Integration tests for the Zowe Python SDK z/OS Tso package."""
 import unittest
-from zowe.zos_tso_for_zowe_sdk import Tso
+
 from zowe.core_for_zowe_sdk import ProfileManager
+from zowe.zos_tso_for_zowe_sdk import Tso
 
 
 class TestTsoIntegration(unittest.TestCase):
@@ -35,4 +36,3 @@ class TestTsoIntegration(unittest.TestCase):
         """Executing the ping_tso_session method should return a failure message for invalid TSO session."""
         command_output = self.tso.ping_tso_session("INVALID")
         self.assertEqual(command_output, "Ping failed")
-

--- a/tests/integration/test_zosmf.py
+++ b/tests/integration/test_zosmf.py
@@ -1,7 +1,8 @@
 """Integration tests for the Zowe Python SDK z/OSMF package."""
 import unittest
-from zowe.zosmf_for_zowe_sdk import Zosmf
+
 from zowe.core_for_zowe_sdk import ProfileManager
+from zowe.zosmf_for_zowe_sdk import Zosmf
 
 
 class TestZosmfIntegration(unittest.TestCase):

--- a/tests/unit/test_zos_console.py
+++ b/tests/unit/test_zos_console.py
@@ -1,8 +1,9 @@
 """Unit tests for the Zowe Python SDK z/OS Console package."""
 
 import unittest
-from zowe.zos_console_for_zowe_sdk import Console
 from unittest import mock
+
+from zowe.zos_console_for_zowe_sdk import Console
 
 
 class TestConsoleClass(unittest.TestCase):
@@ -10,19 +11,20 @@ class TestConsoleClass(unittest.TestCase):
 
     def setUp(self):
         """Setup fixtures for Console class."""
-        self.session_details = {"host": "mock-url.com",
-                                "user": "Username",
-                                "password": "Password",
-                                "port": 443,
-                                "rejectUnauthorized": True
-                                }
+        self.session_details = {
+            "host": "mock-url.com",
+            "user": "Username",
+            "password": "Password",
+            "port": 443,
+            "rejectUnauthorized": True,
+        }
 
     def test_object_should_be_instance_of_class(self):
         """Created object should be instance of Console class."""
         console = Console(self.session_details)
         self.assertIsInstance(console, Console)
 
-    @mock.patch('requests.Session.send')
+    @mock.patch("requests.Session.send")
     def test_get_response_should_return_messages(self, mock_send_request):
         """Getting z/OS Console response messages on sending a response key"""
         mock_send_request.return_value = mock.Mock(headers={"Content-type": "application/json"}, status_code=200)

--- a/tests/unit/test_zos_files.py
+++ b/tests/unit/test_zos_files.py
@@ -1,6 +1,7 @@
 """Unit tests for the Zowe Python SDK z/OS Files package."""
 import re
 from unittest import TestCase, mock
+
 from zowe.zos_files_for_zowe_sdk import Files, exceptions
 
 
@@ -9,19 +10,20 @@ class TestFilesClass(TestCase):
 
     def setUp(self):
         """Setup fixtures for File class."""
-        self.test_profile = {"host": "mock-url.com",
-                                "user": "Username",
-                                "password": "Password",
-                                "port": 443,
-                                "rejectUnauthorized": True
-                                }
+        self.test_profile = {
+            "host": "mock-url.com",
+            "user": "Username",
+            "password": "Password",
+            "port": 443,
+            "rejectUnauthorized": True,
+        }
 
     def test_object_should_be_instance_of_class(self):
         """Created object should be instance of Files class."""
         files = Files(self.test_profile)
         self.assertIsInstance(files, Files)
 
-    @mock.patch('requests.Session.send')
+    @mock.patch("requests.Session.send")
     def test_delete_uss(self, mock_send_request):
         """Test deleting a directory recursively sends a request"""
         mock_send_request.return_value = mock.Mock(headers={"Content-Type": "application/json"}, status_code=204)
@@ -29,35 +31,41 @@ class TestFilesClass(TestCase):
         Files(self.test_profile).delete_uss("filepath_name", recursive=True)
         mock_send_request.assert_called_once()
 
-    @mock.patch('requests.Session.send')
+    @mock.patch("requests.Session.send")
     def test_create_zFS_file_system(self, mock_send_request):
         """Test creating a zfs sends a request"""
         mock_send_request.return_value = mock.Mock(headers={"Content-Type": "application/json"}, status_code=201)
 
-        Files(self.test_profile).create_zFS_file_system("file_system_name", {"perms":100, "cylsPri": 16777213, "cylsSec": 16777215})
+        Files(self.test_profile).create_zFS_file_system(
+            "file_system_name", {"perms": 100, "cylsPri": 16777213, "cylsSec": 16777215}
+        )
         mock_send_request.assert_called_once()
 
-    @mock.patch('requests.Session.send')
+    @mock.patch("requests.Session.send")
     def test_delete_zFS_file_system(self, mock_send_request):
         """Test deleting a zfs sends a request"""
         mock_send_request.return_value = mock.Mock(headers={"Content-Type": "application/json"}, status_code=204)
 
         Files(self.test_profile).delete_zFS_file_system("file_system_name")
         mock_send_request.assert_called_once()
-    
+
     def test_invalid_permission(self):
         """Test that the correct exception is raised when an invalid permission option is provided"""
         with self.assertRaises(exceptions.InvalidPermsOption) as e_info:
-            Files(self.test_profile).create_zFS_file_system("file_system_name", {"perms": -1, "cylsPri": 16777213, "cylsSec": 16777215})
+            Files(self.test_profile).create_zFS_file_system(
+                "file_system_name", {"perms": -1, "cylsPri": 16777213, "cylsSec": 16777215}
+            )
         self.assertEqual(str(e_info.exception), "Invalid zos-files create command 'perms' option: -1")
 
     def test_invalid_memory_allocation(self):
         """Test that the correct exception is raised when an invalid memory allocation option is provided"""
         with self.assertRaises(exceptions.MaxAllocationQuantityExceeded) as e_info:
-            Files(self.test_profile).create_zFS_file_system("file_system_name", {"perms": 775, "cylsPri": 1677755513, "cylsSec": 16777215})
+            Files(self.test_profile).create_zFS_file_system(
+                "file_system_name", {"perms": 775, "cylsPri": 1677755513, "cylsSec": 16777215}
+            )
         self.assertEqual(str(e_info.exception), "Maximum allocation quantity of 16777215 exceeded")
-    
-    @mock.patch('requests.Session.send')
+
+    @mock.patch("requests.Session.send")
     def test_mount_zFS_file_system(self, mock_send_request):
         """Test mounting a zfs sends a request"""
         mock_send_request.return_value = mock.Mock(headers={"Content-Type": "application/json"}, status_code=204)
@@ -65,7 +73,7 @@ class TestFilesClass(TestCase):
         Files(self.test_profile).mount_file_system("file_system_name", "mount_point")
         mock_send_request.assert_called_once()
 
-    @mock.patch('requests.Session.send')
+    @mock.patch("requests.Session.send")
     def test_unmount_zFS_file_system(self, mock_send_request):
         """Test unmounting a zfs sends a request"""
         mock_send_request.return_value = mock.Mock(headers={"Content-Type": "application/json"}, status_code=204)
@@ -73,22 +81,17 @@ class TestFilesClass(TestCase):
         Files(self.test_profile).unmount_file_system("file_system_name")
         mock_send_request.assert_called_once()
 
-    @mock.patch('requests.Session.send')
+    @mock.patch("requests.Session.send")
     def test_list_dsn(self, mock_send_request):
         """Test list DSN sends request"""
         mock_send_request.return_value = mock.Mock(headers={"Content-Type": "application/json"}, status_code=200)
 
-        test_values = [
-            ('MY.DSN',False),
-            ('MY.DSN',True)
-        ]
+        test_values = [("MY.DSN", False), ("MY.DSN", True)]
         for test_case in test_values:
             Files(self.test_profile).list_dsn(*test_case)
             mock_send_request.assert_called()
-       
-        
 
-    @mock.patch('requests.Session.send')
+    @mock.patch("requests.Session.send")
     def test_list_zFS_file_system(self, mock_send_request):
         """Test unmounting a zfs sends a request"""
         mock_send_request.return_value = mock.Mock(headers={"Content-Type": "application/json"}, status_code=200)
@@ -96,71 +99,70 @@ class TestFilesClass(TestCase):
         Files(self.test_profile).list_unix_file_systems("file_system_name")
         mock_send_request.assert_called_once()
 
-    @mock.patch('requests.Session.send')
+    @mock.patch("requests.Session.send")
     def test_recall_migrated_dataset(self, mock_send_request):
         """Test recalling migrated data set sends a request"""
         mock_send_request.return_value = mock.Mock(headers={"Content-Type": "application/json"}, status_code=200)
 
         Files(self.test_profile).recall_migrated_dataset("dataset_name")
         mock_send_request.assert_called_once()
-    
-    @mock.patch('requests.Session.send')
+
+    @mock.patch("requests.Session.send")
     def test_copy_uss_to_dataset(self, mock_send_request):
         """Test copy_uss_to_dataset sends a request"""
-        
+
         mock_send_request.return_value = mock.Mock(headers={"Content-Type": "application/json"}, status_code=200)
 
-        Files(self.test_profile).copy_uss_to_dataset("from_filename","to_dataset_name","to_member_name",replace=True)
-        
-        
+        Files(self.test_profile).copy_uss_to_dataset("from_filename", "to_dataset_name", "to_member_name", replace=True)
+
         mock_send_request.assert_called_once()
-   
+
     def test_copy_dataset_or_member_raises_exception(self):
         """Test copying a data set or member raises error when assigning invalid values to enq parameter"""
 
         test_case = {
-        "from_dataset_name": "MY.OLD.DSN",
-        "to_dataset_name": "MY.NEW.DSN",
-        "from_member_name": "MYMEM1",
-        "to_member_name": "MYMEM2",
-        "enq": "RANDOM",
-        "replace": True
+            "from_dataset_name": "MY.OLD.DSN",
+            "to_dataset_name": "MY.NEW.DSN",
+            "from_member_name": "MYMEM1",
+            "to_member_name": "MYMEM2",
+            "enq": "RANDOM",
+            "replace": True,
         }
         with self.assertRaises(ValueError) as e_info:
             Files(self.test_profile).copy_dataset_or_member(**test_case)
         self.assertEqual(str(e_info.exception), "Invalid value for enq.")
-            
-    @mock.patch('requests.Session.send')
+
+    @mock.patch("requests.Session.send")
     def test_copy_dataset_or_member(self, mock_send_request):
         """Test copying a data set or member sends a request"""
-        
+
         mock_send_request.return_value = mock.Mock(headers={"Content-Type": "application/json"}, status_code=200)
         test_values = [
-           {
-        "from_dataset_name": "MY.OLD.DSN",
-        "to_dataset_name": "MY.NEW.DSN",
-        "from_member_name": "MYMEM1",
-        "to_member_name": "MYMEM2",
-        "volser":'ABC',
-        "alias":False,
-        "enq": "SHRW",
-        "replace": False
-        },
-           {
-        "from_dataset_name": "MY.OLD.DSN",
-        "to_dataset_name": "MY.NEW.DSN",
-        "from_member_name": "MYMEM1",
-        "to_member_name": "MYMEM2",
-        "volser":'ABC',
-        "alias":True,
-        "enq": "SHRW",
-        "replace": True
-        }
+            {
+                "from_dataset_name": "MY.OLD.DSN",
+                "to_dataset_name": "MY.NEW.DSN",
+                "from_member_name": "MYMEM1",
+                "to_member_name": "MYMEM2",
+                "volser": "ABC",
+                "alias": False,
+                "enq": "SHRW",
+                "replace": False,
+            },
+            {
+                "from_dataset_name": "MY.OLD.DSN",
+                "to_dataset_name": "MY.NEW.DSN",
+                "from_member_name": "MYMEM1",
+                "to_member_name": "MYMEM2",
+                "volser": "ABC",
+                "alias": True,
+                "enq": "SHRW",
+                "replace": True,
+            },
         ]
         for test_case in test_values:
             Files(self.test_profile).copy_dataset_or_member(**test_case)
             mock_send_request.assert_called()
-            
+
     def test_recall_migrated_dataset_parameterized(self):
         """Testing recall migrated_dataset with different values"""
 
@@ -176,18 +178,17 @@ class TestFilesClass(TestCase):
         for test_case in test_values:
             files_test_profile.request_handler.perform_request = mock.Mock()
 
-            data = {
-                "request": "hrecall",
-                "wait": test_case[1]
-            }
+            data = {"request": "hrecall", "wait": test_case[1]}
 
             files_test_profile.recall_migrated_dataset(test_case[0], test_case[1])
             custom_args = files_test_profile._create_custom_request_arguments()
             custom_args["json"] = data
             custom_args["url"] = "https://mock-url.com:443/zosmf/restfiles/ds/{}".format(test_case[0])
-            files_test_profile.request_handler.perform_request.assert_called_once_with("PUT", custom_args, expected_code=[200])
+            files_test_profile.request_handler.perform_request.assert_called_once_with(
+                "PUT", custom_args, expected_code=[200]
+            )
 
-    @mock.patch('requests.Session.send')
+    @mock.patch("requests.Session.send")
     def test_delete_migrated_data_set(self, mock_send_request):
         """Test deleting a migrated data set sends a request"""
         mock_send_request.return_value = mock.Mock(headers={"Content-Type": "application/json"}, status_code=200)
@@ -216,16 +217,17 @@ class TestFilesClass(TestCase):
                 "request": "hdelete",
                 "purge": test_case[1],
                 "wait": test_case[2],
-
             }
 
             files_test_profile.delete_migrated_data_set(test_case[0], test_case[1], test_case[2])
             custom_args = files_test_profile._create_custom_request_arguments()
             custom_args["json"] = data
             custom_args["url"] = "https://mock-url.com:443/zosmf/restfiles/ds/{}".format(test_case[0])
-            files_test_profile.request_handler.perform_request.assert_called_once_with("PUT", custom_args, expected_code=[200])
+            files_test_profile.request_handler.perform_request.assert_called_once_with(
+                "PUT", custom_args, expected_code=[200]
+            )
 
-    @mock.patch('requests.Session.send')
+    @mock.patch("requests.Session.send")
     def test_migrate_data_set(self, mock_send_request):
         """Test migrating a data set sends a request"""
         mock_send_request.return_value = mock.Mock(headers={"Content-Type": "application/json"}, status_code=200)
@@ -258,9 +260,11 @@ class TestFilesClass(TestCase):
             custom_args = files_test_profile._create_custom_request_arguments()
             custom_args["json"] = data
             custom_args["url"] = "https://mock-url.com:443/zosmf/restfiles/ds/{}".format(test_case[0])
-            files_test_profile.request_handler.perform_request.assert_called_once_with("PUT", custom_args, expected_code=[200])
+            files_test_profile.request_handler.perform_request.assert_called_once_with(
+                "PUT", custom_args, expected_code=[200]
+            )
 
-    @mock.patch('requests.Session.send')
+    @mock.patch("requests.Session.send")
     def test_rename_dataset(self, mock_send_request):
         """Test renaming dataset sends a request"""
         mock_send_request.return_value = mock.Mock(headers={"Content-Type": "application/json"}, status_code=200)
@@ -271,9 +275,9 @@ class TestFilesClass(TestCase):
     def test_rename_dataset_parametrized(self):
         """Test renaming a dataset with different values"""
         test_values = [
-            (('DSN.OLD', "DSN.NEW"), True),
-            (('DS.NAME.CURRENT', "DS.NAME.NEW"), True),
-            (('MY.OLD.DSN', "MY.NEW.DSN"), True),
+            (("DSN.OLD", "DSN.NEW"), True),
+            (("DS.NAME.CURRENT", "DS.NAME.NEW"), True),
+            (("MY.OLD.DSN", "MY.NEW.DSN"), True),
         ]
 
         files_test_profile = Files(self.test_profile)
@@ -285,7 +289,7 @@ class TestFilesClass(TestCase):
                 "request": "rename",
                 "from-dataset": {
                     "dsn": test_case[0][0].strip(),
-                }
+                },
             }
 
             files_test_profile.rename_dataset(test_case[0][0], test_case[0][1])
@@ -293,9 +297,11 @@ class TestFilesClass(TestCase):
             custom_args = files_test_profile._create_custom_request_arguments()
             custom_args["json"] = data
             custom_args["url"] = "https://mock-url.com:443/zosmf/restfiles/ds/{}".format(test_case[0][1])
-            files_test_profile.request_handler.perform_request.assert_called_once_with("PUT", custom_args, expected_code=[200])
+            files_test_profile.request_handler.perform_request.assert_called_once_with(
+                "PUT", custom_args, expected_code=[200]
+            )
 
-    @mock.patch('requests.Session.send')
+    @mock.patch("requests.Session.send")
     def test_rename_dataset_member(self, mock_send_request):
         """Test renaming dataset member sends a request"""
         mock_send_request.return_value = mock.Mock(headers={"Content-Type": "application/json"}, status_code=200)
@@ -312,11 +318,11 @@ class TestFilesClass(TestCase):
     def test_rename_dataset_member_parametrized(self):
         """Test renaming a dataset member with different values"""
         test_values = [
-            (('DSN', "MBROLD$", "MBRNEW$", "EXCLU"), True),
-            (('DSN', "MBROLD#", "MBRNE#", "SHRW"), True),
-            (('DSN', "MBROLD", "MBRNEW", "INVALID"), False),
-            (('DATA.SET.@NAME', 'MEMBEROLD', 'MEMBERNEW'), True),
-            (('DS.NAME', "MONAME", "MNNAME"), True),
+            (("DSN", "MBROLD$", "MBRNEW$", "EXCLU"), True),
+            (("DSN", "MBROLD#", "MBRNE#", "SHRW"), True),
+            (("DSN", "MBROLD", "MBRNEW", "INVALID"), False),
+            (("DATA.SET.@NAME", "MEMBEROLD", "MEMBERNEW"), True),
+            (("DS.NAME", "MONAME", "MNNAME"), True),
         ]
 
         files_test_profile = Files(self.test_profile)
@@ -329,7 +335,7 @@ class TestFilesClass(TestCase):
                 "from-dataset": {
                     "dsn": test_case[0][0].strip(),
                     "member": test_case[0][1].strip(),
-                }
+                },
             }
 
             if len(test_case[0]) > 3:
@@ -340,11 +346,12 @@ class TestFilesClass(TestCase):
                 custom_args["json"] = data
                 ds_path = "{}({})".format(test_case[0][0], test_case[0][2])
                 ds_path_adjusted = files_test_profile._encode_uri_component(ds_path)
-                self.assertNotRegex(ds_path_adjusted, r'[\$\@\#]')
-                self.assertRegex(ds_path_adjusted, r'[\(' + re.escape(test_case[0][2]) + r'\)]')
+                self.assertNotRegex(ds_path_adjusted, r"[\$\@\#]")
+                self.assertRegex(ds_path_adjusted, r"[\(" + re.escape(test_case[0][2]) + r"\)]")
                 custom_args["url"] = "https://mock-url.com:443/zosmf/restfiles/ds/{}".format(ds_path_adjusted)
-                files_test_profile.request_handler.perform_request.assert_called_once_with("PUT", custom_args,
-                                                                                           expected_code=[200])
+                files_test_profile.request_handler.perform_request.assert_called_once_with(
+                    "PUT", custom_args, expected_code=[200]
+                )
             else:
                 with self.assertRaises(ValueError) as e_info:
                     files_test_profile.rename_dataset_member(*test_case[0])
@@ -353,13 +360,9 @@ class TestFilesClass(TestCase):
     def test_create_data_set_raises_error_without_required_arguments(self):
         """Test not providing required arguments raises an error"""
         with self.assertRaises(ValueError) as e_info:
-            obj = Files(self.test_profile).create_data_set("DSNAME123", options={
-                "alcunit": "CYL",
-                "dsorg": "PO",
-                "recfm": "FB",
-                "blksize": 6160,
-                "dirblk": 25
-            })
+            obj = Files(self.test_profile).create_data_set(
+                "DSNAME123", options={"alcunit": "CYL", "dsorg": "PO", "recfm": "FB", "blksize": 6160, "dirblk": 25}
+            )
         self.assertEqual(str(e_info.exception), "If 'like' is not specified, you must specify 'primary' or 'lrecl'.")
 
     def test_create_data_set_raises_error_with_invalid_arguments_parameterized(self):
@@ -372,7 +375,7 @@ class TestFilesClass(TestCase):
                 "dirblk": 5,
                 "recfm": "FB",
                 "blksize": 6160,
-                "lrecl": 80
+                "lrecl": 80,
             },
             {
                 "dsorg": "PO",
@@ -381,7 +384,7 @@ class TestFilesClass(TestCase):
                 "recfm": "invalid",
                 "blksize": 32760,
                 "lrecl": 260,
-                "dirblk": 25
+                "dirblk": 25,
             },
             {
                 "alcunit": "CYL",
@@ -390,7 +393,7 @@ class TestFilesClass(TestCase):
                 "dirblk": 5,
                 "recfm": "FB",
                 "blksize": 6160,
-                "lrecl": 80
+                "lrecl": 80,
             },
             {
                 "dsorg": "PO",
@@ -399,7 +402,7 @@ class TestFilesClass(TestCase):
                 "recfm": "U",
                 "blksize": 27998,
                 "lrecl": 27998,
-                "dirblk": 0
+                "dirblk": 0,
             },
             {
                 "alcunit": "CYL",
@@ -408,8 +411,8 @@ class TestFilesClass(TestCase):
                 "dirblk": 5,
                 "recfm": "FB",
                 "blksize": 6160,
-                "lrecl": 80
-            }
+                "lrecl": 80,
+            },
         ]
 
         for test_case in test_values:
@@ -419,47 +422,67 @@ class TestFilesClass(TestCase):
     def test_create_dataset_parameterized(self):
         """Test create dataset with different values"""
         test_values = [
-            (("DSN", {
-                "alcunit": "CYL",
-                "dsorg": "PO",
-                "primary": 1,
-                "dirblk": 5,
-                "recfm": "FB",
-                "blksize": 6160,
-                "lrecl": 80
-            }), True),
-            (("DSN", {
-                "alcunit": "CYL",
-                "dsorg": "PO",
-                "primary": 1,
-                "recfm": "FB",
-                "blksize": 6160,
-                "lrecl": 80,
-                "dirblk": 25
-            }), True),
-            (("DSN", {
-                "dsorg": "PO",
-                "alcunit": "CYL",
-                "primary": 1,
-                "recfm": "VB",
-                "blksize": 32760,
-                "lrecl": 260,
-                "dirblk": 25
-            }), True),
-            (("DSN", {
-                "alcunit": "CYL",
-                "dsorg": "PS",
-                "primary": 1,
-                "recfm": "FB",
-                "blksize": 6160,
-                "lrecl": 80
-            }), True),
-            (("DSN", {
-                "alcunit": "CYL",
-                "dsorg": "PS",
-                "recfm": "FB",
-                "blksize": 6160,
-            }), False),
+            (
+                (
+                    "DSN",
+                    {
+                        "alcunit": "CYL",
+                        "dsorg": "PO",
+                        "primary": 1,
+                        "dirblk": 5,
+                        "recfm": "FB",
+                        "blksize": 6160,
+                        "lrecl": 80,
+                    },
+                ),
+                True,
+            ),
+            (
+                (
+                    "DSN",
+                    {
+                        "alcunit": "CYL",
+                        "dsorg": "PO",
+                        "primary": 1,
+                        "recfm": "FB",
+                        "blksize": 6160,
+                        "lrecl": 80,
+                        "dirblk": 25,
+                    },
+                ),
+                True,
+            ),
+            (
+                (
+                    "DSN",
+                    {
+                        "dsorg": "PO",
+                        "alcunit": "CYL",
+                        "primary": 1,
+                        "recfm": "VB",
+                        "blksize": 32760,
+                        "lrecl": 260,
+                        "dirblk": 25,
+                    },
+                ),
+                True,
+            ),
+            (
+                ("DSN", {"alcunit": "CYL", "dsorg": "PS", "primary": 1, "recfm": "FB", "blksize": 6160, "lrecl": 80}),
+                True,
+            ),
+            (
+                (
+                    "DSN",
+                    {
+                        "alcunit": "CYL",
+                        "dsorg": "PS",
+                        "recfm": "FB",
+                        "blksize": 6160,
+                    },
+                ),
+                False,
+            ),
         ]
 
         files_test_profile = Files(self.test_profile)
@@ -472,13 +495,17 @@ class TestFilesClass(TestCase):
                 custom_args = files_test_profile._create_custom_request_arguments()
                 custom_args["json"] = test_case[0][1]
                 custom_args["url"] = "https://mock-url.com:443/zosmf/restfiles/ds/{}".format(test_case[0][0])
-                files_test_profile.request_handler.perform_request.assert_called_once_with("POST", custom_args, expected_code=[201])
+                files_test_profile.request_handler.perform_request.assert_called_once_with(
+                    "POST", custom_args, expected_code=[201]
+                )
             else:
                 with self.assertRaises(ValueError) as e_info:
                     files_test_profile.create_data_set(*test_case[0])
-                self.assertEqual(str(e_info.exception), "If 'like' is not specified, you must specify 'primary' or 'lrecl'.")
+                self.assertEqual(
+                    str(e_info.exception), "If 'like' is not specified, you must specify 'primary' or 'lrecl'."
+                )
 
-    @mock.patch('requests.Session.send')
+    @mock.patch("requests.Session.send")
     def test_create_default_dataset(self, mock_send_request):
         """Test creating a default data set sends a request"""
         mock_send_request.return_value = mock.Mock(headers={"Content-Type": "application/json"}, status_code=201)
@@ -510,7 +537,7 @@ class TestFilesClass(TestCase):
                     "dirblk": 5,
                     "recfm": "FB",
                     "blksize": 6160,
-                    "lrecl": 80
+                    "lrecl": 80,
                 },
                 "sequential": {
                     "alcunit": "CYL",
@@ -518,7 +545,7 @@ class TestFilesClass(TestCase):
                     "primary": 1,
                     "recfm": "FB",
                     "blksize": 6160,
-                    "lrecl": 80
+                    "lrecl": 80,
                 },
                 "classic": {
                     "alcunit": "CYL",
@@ -527,7 +554,7 @@ class TestFilesClass(TestCase):
                     "recfm": "FB",
                     "blksize": 6160,
                     "lrecl": 80,
-                    "dirblk": 25
+                    "dirblk": 25,
                 },
                 "c": {
                     "dsorg": "PO",
@@ -536,7 +563,7 @@ class TestFilesClass(TestCase):
                     "recfm": "VB",
                     "blksize": 32760,
                     "lrecl": 260,
-                    "dirblk": 25
+                    "dirblk": 25,
                 },
                 "binary": {
                     "dsorg": "PO",
@@ -545,8 +572,8 @@ class TestFilesClass(TestCase):
                     "recfm": "U",
                     "blksize": 27998,
                     "lrecl": 27998,
-                    "dirblk": 25
-                }
+                    "dirblk": 25,
+                },
             }
 
             if test_case[1]:
@@ -554,7 +581,9 @@ class TestFilesClass(TestCase):
                 custom_args = files_test_profile._create_custom_request_arguments()
                 custom_args["json"] = options.get(test_case[0][1])
                 custom_args["url"] = "https://mock-url.com:443/zosmf/restfiles/ds/{}".format(test_case[0][0])
-                files_test_profile.request_handler.perform_request.assert_called_once_with("POST", custom_args, expected_code=[201])
+                files_test_profile.request_handler.perform_request.assert_called_once_with(
+                    "POST", custom_args, expected_code=[201]
+                )
             else:
                 with self.assertRaises(ValueError) as e_info:
                     files_test_profile.create_default_data_set(*test_case[0])

--- a/tests/unit/test_zos_jobs.py
+++ b/tests/unit/test_zos_jobs.py
@@ -1,6 +1,7 @@
 """Unit tests for the Zowe Python SDK z/OS Jobs package."""
 
 from unittest import TestCase, mock
+
 from zowe.zos_jobs_for_zowe_sdk import Jobs
 
 
@@ -14,69 +15,69 @@ class TestJobsClass(TestCase):
             "user": "Username",
             "password": "Password",
             "port": 443,
-            "rejectUnauthorized": True
+            "rejectUnauthorized": True,
         }
 
     def test_object_should_be_instance_of_class(self):
         """Created object should be instance of Jobs class."""
         jobs = Jobs(self.test_profile)
         self.assertIsInstance(jobs, Jobs)
-    
-    @mock.patch('requests.Session.send')
+
+    @mock.patch("requests.Session.send")
     def test_cancel_job(self, mock_send_request):
         """Test cancelling a job sends a request"""
         mock_send_request.return_value = mock.Mock(headers={"Content-Type": "application/json"}, status_code=200)
 
-        Jobs(self.test_profile).cancel_job("TESTJOB2","JOB00084")
+        Jobs(self.test_profile).cancel_job("TESTJOB2", "JOB00084")
         mock_send_request.assert_called_once()
-    
-    @mock.patch('requests.Session.send')
+
+    @mock.patch("requests.Session.send")
     def test_hold_job(self, mock_send_request):
         """Test holding a job sends a request"""
         mock_send_request.return_value = mock.Mock(headers={"Content-Type": "application/json"}, status_code=200)
 
-        Jobs(self.test_profile).hold_job("TESTJOB2","JOB00084")
+        Jobs(self.test_profile).hold_job("TESTJOB2", "JOB00084")
         mock_send_request.assert_called_once()
 
-    @mock.patch('requests.Session.send')
+    @mock.patch("requests.Session.send")
     def test_modified_version_hold_job(self, mock_send_request):
         """Test holding a job sends a request"""
         mock_send_request.return_value = mock.Mock(headers={"Content-Type": "application/json"}, status_code=200)
 
         with self.assertRaises(ValueError):
-            Jobs(self.test_profile).hold_job("TESTJOB2","JOB00084",modify_version="3.0")
-    
-    @mock.patch('requests.Session.send')
+            Jobs(self.test_profile).hold_job("TESTJOB2", "JOB00084", modify_version="3.0")
+
+    @mock.patch("requests.Session.send")
     def test_modified_version_release_job(self, mock_send_request):
         """Test holding a job sends a request"""
         mock_send_request.return_value = mock.Mock(headers={"Content-Type": "application/json"}, status_code=200)
 
         with self.assertRaises(ValueError):
-            Jobs(self.test_profile).release_job("TESTJOB2","JOB00084",modify_version="3.0")
-    
-    @mock.patch('requests.Session.send')
+            Jobs(self.test_profile).release_job("TESTJOB2", "JOB00084", modify_version="3.0")
+
+    @mock.patch("requests.Session.send")
     def test_release_job(self, mock_send_request):
         """Test releasing a job sends a request"""
         mock_send_request.return_value = mock.Mock(headers={"Content-Type": "application/json"}, status_code=200)
 
-        Jobs(self.test_profile).release_job("TESTJOB2","JOB00084")
+        Jobs(self.test_profile).release_job("TESTJOB2", "JOB00084")
         mock_send_request.assert_called_once()
 
-    @mock.patch('requests.Session.send')
+    @mock.patch("requests.Session.send")
     def test_change_job_class(self, mock_send_request):
         """Test changing the job class sends a request"""
         mock_send_request.return_value = mock.Mock(headers={"Content-Type": "application/json"}, status_code=200)
 
-        Jobs(self.test_profile).change_job_class("TESTJOB2","JOB00084","A")
+        Jobs(self.test_profile).change_job_class("TESTJOB2", "JOB00084", "A")
         mock_send_request.assert_called_once()
 
-    @mock.patch('requests.Session.send')
+    @mock.patch("requests.Session.send")
     def test_modified_version_error(self, mock_send_request):
         """Test modified version should raise value error"""
         mock_send_request.return_value = mock.Mock(headers={"Content-Type": "application/json"}, status_code=200)
 
         with self.assertRaises(ValueError):
-            Jobs(self.test_profile).change_job_class("TESTJOB2","JOB00084","A",modify_version="3.0")
+            Jobs(self.test_profile).change_job_class("TESTJOB2", "JOB00084", "A", modify_version="3.0")
 
     def test_cancel_job_modify_version_parameterized(self):
         """Test cancelling a job with different values sends the expected request"""
@@ -102,9 +103,11 @@ class TestJobsClass(TestCase):
                 }
                 job_url = "{}/{}".format(test_case[0][0], test_case[0][1])
                 job_url_adjusted = jobs_test_object._encode_uri_component(job_url)
-                self.assertNotRegex(job_url_adjusted, r'\$')
+                self.assertNotRegex(job_url_adjusted, r"\$")
                 custom_args["url"] = "https://mock-url.com:443/zosmf/restjobs/jobs/{}".format(job_url_adjusted)
-                jobs_test_object.request_handler.perform_request.assert_called_once_with("PUT", custom_args, expected_code=[202, 200])
+                jobs_test_object.request_handler.perform_request.assert_called_once_with(
+                    "PUT", custom_args, expected_code=[202, 200]
+                )
             else:
                 with self.assertRaises(ValueError) as e_info:
                     jobs_test_object.cancel_job(*test_case[0])

--- a/tests/unit/test_zos_tso.py
+++ b/tests/unit/test_zos_tso.py
@@ -1,6 +1,7 @@
 """Unit tests for the Zowe Python SDK z/OS TSO package."""
 
 import unittest
+
 from zowe.zos_tso_for_zowe_sdk import Tso
 
 
@@ -9,12 +10,13 @@ class TestTsoClass(unittest.TestCase):
 
     def setUp(self):
         """Setup fixtures for Tso class."""
-        self.connection_dict = {"host": "mock-url.com",
-                                "user": "Username",
-                                "password": "Password",
-                                "port": 443,
-                                "rejectUnauthorized": True
-                                }
+        self.connection_dict = {
+            "host": "mock-url.com",
+            "user": "Username",
+            "password": "Password",
+            "port": 443,
+            "rejectUnauthorized": True,
+        }
 
     def test_object_should_be_instance_of_class(self):
         """Created object should be instance of Tso class."""

--- a/tests/unit/test_zosmf.py
+++ b/tests/unit/test_zosmf.py
@@ -2,6 +2,7 @@
 
 import unittest
 from unittest import mock
+
 from zowe.zosmf_for_zowe_sdk import Zosmf
 
 
@@ -10,21 +11,22 @@ class TestZosmfClass(unittest.TestCase):
 
     def setUp(self):
         """Setup fixtures for Zosmf class."""
-        self.connection_dict = {"host": "mock-url.com",
-                                "user": "Username",
-                                "password": "Password",
-                                "port": 443,
-                                "rejectUnauthorized": True
-                                }
+        self.connection_dict = {
+            "host": "mock-url.com",
+            "user": "Username",
+            "password": "Password",
+            "port": 443,
+            "rejectUnauthorized": True,
+        }
 
     def test_object_should_be_instance_of_class(self):
         """Created object should be instance of Zosmf class."""
         zosmf = Zosmf(self.connection_dict)
         self.assertIsInstance(zosmf, Zosmf)
 
-    @mock.patch('requests.Session.send')
+    @mock.patch("requests.Session.send")
     def test_list_systems(self, mock_send_request):
         """Listing z/OSMF systems should send a REST request"""
         mock_send_request.return_value = mock.Mock(headers={"Content-Type": "application/json"}, status_code=200)
         Zosmf(self.connection_dict).list_systems()
-        mock_send_request.assert_called_once() 
+        mock_send_request.assert_called_once()


### PR DESCRIPTION
* Formats all code with `black` using default rules except line length of 120 (instead of 88)
* Formats all code with `isort` to organize imports
* Adds VS Code settings to enable automatic formatting