### PR TITLE
Update release workflow

### DIFF
--- a/.github/workflows/sdk-release.yaml
+++ b/.github/workflows/sdk-release.yaml
@@ -27,14 +27,14 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip twine
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
       - name: Update version
         id: update-version
         shell: python
         run: |
-          import sys
+          import os, sys
           sys.path.append("src")
           from _version import __version__
           new_version = "${{ inputs.version }}"
@@ -43,8 +43,9 @@ jobs:
               f.write("__version__ = \"" + new_version + "\"\n")
           else:
             new_version = __version__
-          print("::set-output name=version::" + new_version)
-          print("::set-output name=cargo-version::" + ("-".join(new_version.rsplit(".", 1)) if new_version.count(".") > 2 else new_version))
+          with open(os.environ["GITHUB_OUTPUT"], 'a') as f:
+            print("version=" + new_version, file=f)
+            print("cargo-version=" + ("-".join(new_version.rsplit(".", 1)) if new_version.count(".") > 2 else new_version), file=f)
 
       - name: Update version (cargo)
         run: cargo install cargo-edit && cargo set-version ${{ steps.update-version.outputs.cargo-version }}

--- a/.github/workflows/sdk-release.yaml
+++ b/.github/workflows/sdk-release.yaml
@@ -57,6 +57,7 @@ jobs:
       - name: Archive artifacts
         uses: actions/upload-artifact@v3
         with:
+          name: sdist
           path: dist/
 
       - uses: zowe-actions/octorelease@feat/add-pypi-plugin

--- a/.github/workflows/sdk-release.yaml
+++ b/.github/workflows/sdk-release.yaml
@@ -68,7 +68,7 @@ jobs:
           GIT_COMMITTER_EMAIL: ${{ secrets.ZOWE_ROBOT_EMAIL }}
           GIT_CREDENTIALS: x-access-token:${{ secrets.ZOWE_ROBOT_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TWINE_USERNAME: _token_
+          TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_ROBOT_TOKEN }}
         with:
           dry-run: ${{ inputs.dry-run }}

--- a/.github/workflows/sdk-release.yaml
+++ b/.github/workflows/sdk-release.yaml
@@ -44,11 +44,10 @@ jobs:
           else:
             new_version = __version__
           with open(os.environ["GITHUB_OUTPUT"], 'a') as f:
-            print("version=" + new_version, file=f)
-            print("cargo-version=" + ("-".join(new_version.rsplit(".", 1)) if new_version.count(".") > 2 else new_version), file=f)
+            print("version=" + ("-".join(new_version.rsplit(".", 1)) if new_version.count(".") > 2 else new_version), file=f)
 
       - name: Update version (cargo)
-        run: cargo install cargo-edit && cargo set-version ${{ steps.update-version.outputs.cargo-version }}
+        run: cargo install cargo-edit && cargo set-version ${{ steps.update-version.outputs.version }}
         working-directory: src/secrets
 
       - name: Update version (git)

--- a/.github/workflows/sdk-release.yaml
+++ b/.github/workflows/sdk-release.yaml
@@ -53,13 +53,13 @@ jobs:
       - name: Update version (git)
         run: git add src/_version.py src/secrets/Cargo.*
 
-      - name: Build dist wheels
+      - name: Build wheels
         run: bash build.sh
 
-      - name: Archive artifacts
+      - name: Upload wheels
         uses: actions/upload-artifact@v3
         with:
-          name: sdist
+          name: wheels
           path: dist/
 
       - uses: zowe-actions/octorelease@feat/add-pypi-plugin

--- a/.github/workflows/sdk-release.yaml
+++ b/.github/workflows/sdk-release.yaml
@@ -51,6 +51,9 @@ jobs:
         run: cargo install cargo-edit && cargo set-version ${{ steps.update-version.outputs.cargo-version }}
         working-directory: src/secrets
 
+      - name: Update version (git)
+        run: git add src/_version.py src/secrets/Cargo.*
+
       - name: Build dist wheels
         run: bash build.sh
 

--- a/.github/workflows/secrets-sdk.yml
+++ b/.github/workflows/secrets-sdk.yml
@@ -10,9 +10,12 @@ on:
     paths:
       - "src/secrets/**"
       - ".github/workflows/secrets-sdk.yml"
+    tags:
+      - "*"
   pull_request:
     paths:
       - "src/secrets/**"
+  workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/secrets-sdk.yml
+++ b/.github/workflows/secrets-sdk.yml
@@ -48,7 +48,7 @@ jobs:
           working-directory: src/secrets
           before-script-linux: |
             if command -v yum &> /dev/null; then
-              yum update && yum install -y libsecret-devel.${{ env.CROSS_DEB_ARCH }} pkgconfig
+              yum update -y && yum install -y libsecret-devel.${{ env.CROSS_DEB_ARCH }} pkgconfig
             else
               dpkg --add-architecture ${{ env.CROSS_DEB_ARCH }}
               sed -i "s/deb /deb [arch=amd64] /g" /etc/apt/sources.list

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Zowe Client Python SDK will be documented in this file.
 
-## Recent Changes
+## `1.0.0-dev11`
 
 ### Enhancements
 

--- a/release.config.js
+++ b/release.config.js
@@ -7,10 +7,6 @@ module.exports = {
         {
             name: "zowe-v?-lts",
             level: "patch"
-        },
-        {
-            name: "fix/update-release-workflow",
-            level: "major"
         }
         // {
         //     name: "next",

--- a/release.config.js
+++ b/release.config.js
@@ -10,7 +10,7 @@ module.exports = {
         },
         {
             name: "fix/update-release-workflow",
-            level: "patch"
+            level: "major"
         }
         // {
         //     name: "next",

--- a/release.config.js
+++ b/release.config.js
@@ -7,6 +7,10 @@ module.exports = {
         {
             name: "zowe-v?-lts",
             level: "patch"
+        },
+        {
+            name: "fix/update-release-workflow",
+            level: "patch"
         }
         // {
         //     name: "next",

--- a/src/_version.py
+++ b/src/_version.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0.dev10"
+__version__ = "1.0.0.dev11"

--- a/src/secrets/Cargo.lock
+++ b/src/secrets/Cargo.lock
@@ -241,7 +241,7 @@ checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
 
 [[package]]
 name = "keyring"
-version = "1.0.0-dev10"
+version = "1.0.0-dev11"
 dependencies = [
  "pyo3",
  "secrets_core",

--- a/src/secrets/Cargo.toml
+++ b/src/secrets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keyring"
-version = "1.0.0-dev10"
+version = "1.0.0-dev11"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Fix the release workflow - on this branch it successfully published packages to PyPI except for the Secrets SDK which we can trigger with `workflow_dispatch` after this PR is merged 🙂 