### PR TITLE
Update release workflow #2

### DIFF
--- a/.github/workflows/sdk-release.yaml
+++ b/.github/workflows/sdk-release.yaml
@@ -62,7 +62,7 @@ jobs:
           name: wheels
           path: dist/
 
-      - uses: zowe-actions/octorelease@feat/add-pypi-plugin
+      - uses: zowe-actions/octorelease@v1
         env:
           GIT_COMMITTER_NAME: ${{ secrets.ZOWE_ROBOT_USER }}
           GIT_COMMITTER_EMAIL: ${{ secrets.ZOWE_ROBOT_EMAIL }}

--- a/.github/workflows/secrets-sdk.yml
+++ b/.github/workflows/secrets-sdk.yml
@@ -144,4 +144,3 @@ jobs:
         with:
           command: upload
           args: --non-interactive --skip-existing *
-          working-directory: src/secrets


### PR DESCRIPTION
* Updates Octorelease ref to `v1` since the branch ref will stop working after https://github.com/zowe-actions/octorelease/pull/122 is merged
* Don't change directory to release Secrets SDK wheels with `maturin-action`