### PR TITLE
return response instead of raw for stream requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Zowe Client Python SDK will be documented in this fil
 ### Bug Fixes
 
 - Fixed 'create_data_set' to accept "FBA", "FBM", "VBA", "VBM" as valid recfm [#240](https://github.com/zowe/zowe-client-python-sdk/issues/240)
+- Return response instead of raw from streamed requests
 
 ## `1.0.0-dev12`
 

--- a/src/core/zowe/core_for_zowe_sdk/request_handler.py
+++ b/src/core/zowe/core_for_zowe_sdk/request_handler.py
@@ -93,7 +93,7 @@ class RequestHandler:
         self.__validate_method()
         self.__send_request(stream=True)
         self.__validate_response()
-        return self.response.raw
+        return self.response
 
     def __validate_method(self):
         """Check if the input request method for the request is supported.


### PR DESCRIPTION
**What It Does**

- enables use of iterator
- https://requests.readthedocs.io/en/latest/user/quickstart/#raw-response-content

**How to Test**
- Download dataset via stream
```python
response = zosmf_files.get_dsn_content_streamed(dsn)
with open(destination_path, "wb") as fd:
    for chunk in response.iter_content(chunk_size=256):
        fd.write(chunk)
        size += len(chunk)
```

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)