### PR TITLE
Update installation docs for prerelease

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
+PyEnchant>=3.3.0rc1
 sphinx_rtd_theme>=0.5.1
 sphinxcontrib-spelling==8.0.0
 -e ./src/core

--- a/docs/source/usage/examples.rst
+++ b/docs/source/usage/examples.rst
@@ -9,7 +9,7 @@ Create a dictionary to handle communication with the plug-in:
     from zowe.zos_console_for_zowe_sdk import Console
     profile = {
         "host": "<host address>",
-        "port" : 443 , # Include the port if different from the default (443)
+        "port": 443, # Include the port if different from the default (443)
         "user": "<user>",
         "password": "<password>",
     }

--- a/docs/source/usage/installation.rst
+++ b/docs/source/usage/installation.rst
@@ -15,14 +15,12 @@ To install all Zowe SDK packages using pip:
 
 .. code-block::
 
-    pip install zowe
+    pip install -U --pre zowe
 
 To install only a subpackage using pip:
 
 .. code-block::
 
-    pip install zowe.<subpackage>_for_zowe_sdk
+    pip install -U --pre zowe.<subpackage>_for_zowe_sdk
 
 To see all available sub-packages check the :doc:`../packages/packages` section.
-
-


### PR DESCRIPTION
See the updated docs here: https://zowe-client-python-sdk--254.org.readthedocs.build/en/254/usage/installation.html

Also updates the PyEnchant dev dep to support M1 Macs so that I could build the docs from source 😋 