### PR TITLE
Rename Python SDK Bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Zowe Client Python SDK will be documented in this fil
 
 ### Enhancements
 
+- Rename Python SDK bundle [#286](https://github.com/zowe/zowe-client-python-sdk/issues/286)
 - Added logger class to core SDK [#185](https://github.com/zowe/zowe-client-python-sdk/issues/185)
 - Added classes for handling `Datasets`, `USSFiles`, and `FileSystems` in favor of the single Files class. [#264](https://github.com/zowe/zowe-client-python-sdk/issues/264)
 - Refactored tests into proper folders and files and add more tests [#265](https://github.com/zowe/zowe-client-python-sdk/issues/265)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Alternatively, you can choose to install only a single subpackage for a smaller 
 To install all Zowe SDK packages using pip:
 
 ```
-pip install -U --pre zowe
+pip install -U --pre zowe-python-sdk-bundle
 ```
 
 Or, to install a subpackage using pip:

--- a/docs/source/usage/installation.rst
+++ b/docs/source/usage/installation.rst
@@ -15,7 +15,7 @@ To install all Zowe SDK packages using pip:
 
 .. code-block::
 
-    pip install -U --pre zowe
+    pip install -U --pre zowe-python-sdk-bundle
 
 To install only a subpackage using pip:
 

--- a/src/setup.py
+++ b/src/setup.py
@@ -21,7 +21,7 @@ def resolve_sdk_dep(sdk_name, version_spec):
 
 if __name__ == "__main__":
     setup(
-        name="zowe",
+        name="zowe-python-sdk-bundle",
         version=__version__,
         description="Zowe Python SDK",
         long_description=open("../README.md", "r").read(),


### PR DESCRIPTION
**What It Does**
Renames the python SDK bundle. Addresses [#286]

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->