### PR TITLE
Fix _create_custom_request_arguments()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the Zowe Client Python SDK will be documented in this file.
 
+## Recent Changes
+
+### Enhancements
+
+### Bug Fixes
+
+- Fixed a bug on `_create_custom_request_arguments` where modifications on `custom_arguments` will stay after the function returns. [#299](https://github.com/zowe/zowe-client-python-sdk/issues/299)
+
 ## `1.0.0-dev16`
 
 ### Enhancements
@@ -46,11 +54,7 @@ All notable changes to the Zowe Client Python SDK will be documented in this fil
 
 ### Bug Fixes
 
-- *Breaking*: Replaced `datasets` in function names with `data_sets` as a standard. [#83] (https://github.com/zowe/zowe-client-python-sdk/issues/83)
-- *Breaking*: Made unnecessary public variables to private [#83] (https://github.com/zowe/zowe-client-python-sdk/issues/83)
-  - `profile_manager._appname -> profile_manager.__appname`
-  - `profile_manager._show_warnings -> profile_manager.__show_warnings`
-  - `... and others ...`
+- Replaces `datasets` in function names with `data_sets` as a standard and sets unnecessary public variables to private [#83] (https://github.com/zowe/zowe-client-python-sdk/issues/83)
 - Fixed `Files.create_data_set` to accept "FBA", "FBM", "VBA", "VBM" as valid recfm [#240](https://github.com/zowe/zowe-client-python-sdk/issues/240)
 - Fixed an issue with `Jobs.list_jobs` user correlator parameter [#242](https://github.com/zowe/zowe-client-python-sdk/issues/242)
 - Fixed default encoding for I/O operations to be UTF-8 on Windows [#243](https://github.com/zowe/zowe-client-python-sdk/issues/243)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ All notable changes to the Zowe Client Python SDK will be documented in this fil
 
 ### Bug Fixes
 
-- Fixed a bug on `_create_custom_request_arguments` where modifications on `custom_arguments` will affect the variable after the function returns. [#299](https://github.com/zowe/zowe-client-python-sdk/issues/299)
 - Fixed truncated responses when issuing TSO commands [#260](https://github.com/zowe/zowe-client-python-sdk/issues/260)
 - Fixed a bug on `upload_file_to_dsn` where it would not properly convert line endings on Windows. [#104](https://github.com/zowe/zowe-client-python-sdk/issues/104)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to the Zowe Client Python SDK will be documented in this fil
 
 ### Bug Fixes
 
+- Fixed a bug on `_create_custom_request_arguments` where modifications on `custom_arguments` will affect the variable after the function returns. [#299](https://github.com/zowe/zowe-client-python-sdk/issues/299)
 - Fixed truncated responses when issuing TSO commands [#260](https://github.com/zowe/zowe-client-python-sdk/issues/260)
 - Fixed a bug on `upload_file_to_dsn` where it would not properly convert line endings on Windows. [#104](https://github.com/zowe/zowe-client-python-sdk/issues/104)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to the Zowe Client Python SDK will be documented in this fil
 
 ### Bug Fixes
 
+- Fixed a bug on `_create_custom_request_arguments` where modifications on `custom_arguments` will affect the variable after the function returns. [#299](https://github.com/zowe/zowe-client-python-sdk/issues/299)
 - Fixed truncated responses when issuing TSO commands [#260](https://github.com/zowe/zowe-client-python-sdk/issues/260)
 - Fixed a bug on `upload_file_to_dsn` where it would not properly convert line endings on Windows. [#104](https://github.com/zowe/zowe-client-python-sdk/issues/104)
 

--- a/src/core/zowe/core_for_zowe_sdk/sdk_api.py
+++ b/src/core/zowe/core_for_zowe_sdk/sdk_api.py
@@ -10,6 +10,7 @@ SPDX-License-Identifier: EPL-2.0
 Copyright Contributors to the Zowe Project.
 """
 
+import copy
 import urllib
 
 from . import session_constants
@@ -66,7 +67,7 @@ class SdkApi:
         This method is required because the way that Python handles
         dictionary creation
         """
-        return self._request_arguments.copy()
+        return copy.deepcopy(self._request_arguments)
 
     def _encode_uri_component(self, str_to_adjust):
         """Adjust string to be correct in a URL


### PR DESCRIPTION
**What It Does**
Uses deep copy in _create_custom_request_arguments() to prevent conflicts in request arguments. Fixes [#299].

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->