### PR TITLE
Fixes `_create_custom_request_arguments`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ All notable changes to the Zowe Client Python SDK will be documented in this fil
 
 ### Enhancements
 
-- 
-
 ### Bug Fixes
 
 - Fixed a bug on `_create_custom_request_arguments` where changes on `custom_args` will stay after the function returns [#299](https://github.com/zowe/zowe-client-python-sdk/issues/299)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,21 @@
 
 All notable changes to the Zowe Client Python SDK will be documented in this file.
 
+## Recent Changes
+
+### Enhancements
+
+- 
+
+### Bug Fixes
+
+- Fixed a bug on `_create_custom_request_arguments` where changes on `custom_args` will stay after the function returns [#299](https://github.com/zowe/zowe-client-python-sdk/issues/299)
+
 ## `1.0.0-dev16`
 
 ### Enhancements
 
-- Rename Python SDK bundle [#286](https://github.com/zowe/zowe-client-python-sdk/issues/286)
+- Renamed Python SDK bundle [#286](https://github.com/zowe/zowe-client-python-sdk/issues/286)
 - Added logger class to core SDK [#185](https://github.com/zowe/zowe-client-python-sdk/issues/185)
 - Added classes for handling `Datasets`, `USSFiles`, and `FileSystems` in favor of the single Files class. [#264](https://github.com/zowe/zowe-client-python-sdk/issues/264)
 - Refactored tests into proper folders and files and add more tests [#265](https://github.com/zowe/zowe-client-python-sdk/issues/265)

--- a/src/core/zowe/core_for_zowe_sdk/sdk_api.py
+++ b/src/core/zowe/core_for_zowe_sdk/sdk_api.py
@@ -10,6 +10,7 @@ SPDX-License-Identifier: EPL-2.0
 Copyright Contributors to the Zowe Project.
 """
 
+import copy
 import urllib
 
 from . import session_constants
@@ -66,7 +67,7 @@ class SdkApi:
         This method is required because the way that Python handles
         dictionary creation
         """
-        return self._request_arguments.copy()
+        return copy.deepcopy(self._request_arguments)
 
     def _encode_uri_component(self, str_to_adjust):
         """Adjust string to be correct in a URL


### PR DESCRIPTION
**What It Does**
Fixed a bug on `_create_custom_request_arguments` where changes on `custom_args` will stay after the function returns [#299]

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->