### PR TITLE
Support AUTH_TYPE_CERT_PEM and AUTH_TYPE_NONE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the Zowe Client Python SDK will be documented in this fil
 
 ### Enhancements
 
+- Included support for `AUTH_TYPE_CERT_PEM` and `AUTH_TYPE_NONE` in `session` [#291] (https://github.com/zowe/zowe-client-python-sdk/issues/291) and [#296] (https://github.com/zowe/zowe-client-python-sdk/issues/296)
+
 ### Bug Fixes
 
 - Fixed a bug on `create` in `Datasets` where the target dataset gets created with a different block size when `like` is specified [#295] (https://github.com/zowe/zowe-client-python-sdk/issues/295)

--- a/src/core/zowe/core_for_zowe_sdk/sdk_api.py
+++ b/src/core/zowe/core_for_zowe_sdk/sdk_api.py
@@ -54,6 +54,8 @@ class SdkApi:
             self._default_headers["Authorization"] = f"Bearer {self.session.tokenValue}"
         elif self.session.type == session_constants.AUTH_TYPE_TOKEN:
             self._default_headers["Cookie"] = f"{self.session.tokenType}={self.session.tokenValue}"
+        elif self.session.type == session_constants.AUTH_TYPE_CERT_PEM:
+            self.__session_arguments["cert"] = self.session.cert
 
     def __enter__(self):
         return self

--- a/src/core/zowe/core_for_zowe_sdk/session.py
+++ b/src/core/zowe/core_for_zowe_sdk/session.py
@@ -82,7 +82,7 @@ class Session:
         self.session.basePath = props.get("basePath")
         self.session.port = props.get("port", self.session.port)
         self.session.protocol = props.get("protocol", self.session.protocol)
-        self.session.rejectUnauthorized = False if props.get("rejectUnauthorized") is "False" else True
+        self.session.rejectUnauthorized = False if props.get("rejectUnauthorized") == "False" else True
 
     def load(self) -> ISession:
         return self.session

--- a/src/core/zowe/core_for_zowe_sdk/session.py
+++ b/src/core/zowe/core_for_zowe_sdk/session.py
@@ -34,7 +34,6 @@ class ISession:
     tokenType: Optional[str] = None
     tokenValue: Optional[str] = None
     cert: Optional[str] = None
-    certKey: Optional[str] = None
 
 
 class Session:
@@ -66,9 +65,13 @@ class Session:
         elif props.get("tokenValue") is not None:
             self.session.tokenValue = props.get("tokenValue")
             self.session.type = session_constants.AUTH_TYPE_BEARER
-        elif props.get("cert") is not None and props.get("certKey") is not None:
-            self.session.cert = props.get("cert")
-            self.session.certKey = props.get("certKey")
+        elif props.get("certFile") is not None:
+            if props.get("certKeyFile"):
+                self.session.cert = (props.get("certFile"), props.get("certKeyFile"))
+            else:
+                self.__logger.error("A cert key must be provided")
+                raise Exception("A cert key must be provided")
+            self.session.rejectUnauthorized = props.get("rejectUnauthorized")
             self.session.type = session_constants.AUTH_TYPE_CERT_PEM
         else:
             self.session.type = session_constants.AUTH_TYPE_NONE
@@ -79,7 +82,7 @@ class Session:
         self.session.basePath = props.get("basePath")
         self.session.port = props.get("port", self.session.port)
         self.session.protocol = props.get("protocol", self.session.protocol)
-        self.session.rejectUnauthorized = props.get("rejectUnauthorized", self.session.rejectUnauthorized)
+        self.session.rejectUnauthorized = False if props.get("rejectUnauthorized") is "False" else True
 
     def load(self) -> ISession:
         return self.session

--- a/src/core/zowe/core_for_zowe_sdk/session.py
+++ b/src/core/zowe/core_for_zowe_sdk/session.py
@@ -33,6 +33,8 @@ class ISession:
     type: Optional[str] = None
     tokenType: Optional[str] = None
     tokenValue: Optional[str] = None
+    cert: Optional[str] = None
+    certKey: Optional[str] = None
 
 
 class Session:
@@ -64,6 +66,10 @@ class Session:
         elif props.get("tokenValue") is not None:
             self.session.tokenValue = props.get("tokenValue")
             self.session.type = session_constants.AUTH_TYPE_BEARER
+        elif props.get("cert") is not None and props.get("certKey") is not None:
+            self.session.cert = props.get("cert")
+            self.session.certKey = props.get("certKey")
+            self.session.type = session_constants.AUTH_TYPE_CERT_PEM
         else:
             self.session.type = session_constants.AUTH_TYPE_NONE
             self.__logger.info("Authentication method not supplied")

--- a/src/core/zowe/core_for_zowe_sdk/session.py
+++ b/src/core/zowe/core_for_zowe_sdk/session.py
@@ -65,8 +65,9 @@ class Session:
             self.session.tokenValue = props.get("tokenValue")
             self.session.type = session_constants.AUTH_TYPE_BEARER
         else:
-            self.__logger.error("Authentication method not supplied")
-            raise Exception("An authentication method must be supplied")
+            self.session.type = session_constants.AUTH_TYPE_NONE
+            self.__logger.info("Authentication method not supplied")
+            # raise Exception("An authentication method must be supplied")
 
         # set additional parameters
         self.session.basePath = props.get("basePath")

--- a/src/core/zowe/core_for_zowe_sdk/session.py
+++ b/src/core/zowe/core_for_zowe_sdk/session.py
@@ -82,7 +82,7 @@ class Session:
         self.session.basePath = props.get("basePath")
         self.session.port = props.get("port", self.session.port)
         self.session.protocol = props.get("protocol", self.session.protocol)
-        self.session.rejectUnauthorized = False if props.get("rejectUnauthorized") == "False" else True
+        self.session.rejectUnauthorized = False if props.get("rejectUnauthorized") == False else True
 
     def load(self) -> ISession:
         return self.session

--- a/tests/unit/core/test_sdk_api.py
+++ b/tests/unit/core/test_sdk_api.py
@@ -17,7 +17,7 @@ class TestSdkApiClass(TestCase):
         self.basic_props = {**common_props, "user": "Username", "password": "Password"}
         self.bearer_props = {**common_props, "tokenValue": "BearerToken"}
         self.token_props = {**common_props, "tokenType": "MyToken", "tokenValue": "TokenValue"}
-        self.cert_props = {**common_props, "cert": "cert", "certKey": "certKey"}
+        self.cert_props = {**common_props, "rejectUnauthorized": False, "certFile": "cert", "certKeyFile": "certKey"}
         self.default_url = "https://default-api.com/"
 
     def test_object_should_be_instance_of_class(self):
@@ -42,6 +42,19 @@ class TestSdkApiClass(TestCase):
         except Exception:
             mock_logger_error.assert_called()
             self.assertIn("Host", mock_logger_error.call_args[0][0])
+
+    @mock.patch("logging.Logger.error")
+    def test_session_combined_cert_logger(self, mock_logger_error: mock.MagicMock):
+        props = {"host": "test", "certFile": "test"}
+        try:
+            sdk_api = SdkApi(props, self.default_url)
+        except Exception:
+            mock_logger_error.assert_called()
+            self.assertIn("cert key", mock_logger_error.call_args[0][0])
+
+    def test_session_cert(self):
+        sdk_api = SdkApi(self.cert_props, self.default_url)
+        self.assertEqual((self.cert_props.get("certFile"), self.cert_props.get("certKeyFile")), sdk_api.session.cert)
 
     def test_should_handle_none_auth(self):
         props = {"host": "test"}

--- a/tests/unit/core/test_sdk_api.py
+++ b/tests/unit/core/test_sdk_api.py
@@ -52,10 +52,6 @@ class TestSdkApiClass(TestCase):
             mock_logger_error.assert_called()
             self.assertIn("cert key", mock_logger_error.call_args[0][0])
 
-    def test_session_cert(self):
-        sdk_api = SdkApi(self.cert_props, self.default_url)
-        self.assertEqual((self.cert_props.get("certFile"), self.cert_props.get("certKeyFile")), sdk_api.session.cert)
-
     def test_should_handle_none_auth(self):
         props = {"host": "test"}
         sdk_api = SdkApi(props, self.default_url)
@@ -64,8 +60,7 @@ class TestSdkApiClass(TestCase):
     def test_should_handle_cert_auth(self):
         props = self.cert_props
         sdk_api = SdkApi(props, self.default_url)
-        self.assertEqual(sdk_api.session.cert, self.cert_props["cert"])
-        self.assertEqual(sdk_api.session.certKey, self.cert_props["certKey"])
+        self.assertEqual(sdk_api.session.cert, (self.cert_props["certFile"], self.cert_props["certKeyFile"]))
 
     def test_should_handle_basic_auth(self):
         """Created object should handle basic authentication."""

--- a/tests/unit/core/test_sdk_api.py
+++ b/tests/unit/core/test_sdk_api.py
@@ -16,21 +16,18 @@ class TestSdkApiClass(TestCase):
         common_props = {"host": "mock-url.com", "port": 443, "protocol": "https", "rejectUnauthorized": True}
         self.basic_props = {**common_props, "user": "Username", "password": "Password"}
         self.bearer_props = {**common_props, "tokenValue": "BearerToken"}
-        self.token_props = {
-            **common_props,
-            "tokenType": "MyToken",
-            "tokenValue": "TokenValue",
-        }
+        self.token_props = {**common_props, "tokenType": "MyToken", "tokenValue": "TokenValue"}
+        self.cert_props = {**common_props, "cert": "cert", "certKey": "certKey"}
         self.default_url = "https://default-api.com/"
 
     def test_object_should_be_instance_of_class(self):
         """Created object should be instance of SdkApi class."""
         sdk_api = SdkApi(self.basic_props, self.default_url)
         self.assertIsInstance(sdk_api, SdkApi)
-    
-    @mock.patch('requests.Session.close') 
+
+    @mock.patch("requests.Session.close")
     def test_context_manager_closes_session(self, mock_close_request):
-    
+
         mock_close_request.return_value = mock.Mock(headers={"Content-Type": "application/json"}, status_code=200)
         with SdkApi(self.basic_props, self.default_url) as api:
             pass
@@ -46,14 +43,16 @@ class TestSdkApiClass(TestCase):
             mock_logger_error.assert_called()
             self.assertIn("Host", mock_logger_error.call_args[0][0])
 
-    @mock.patch("logging.Logger.error")
-    def test_session_no_authentication_logger(self, mock_logger_error: mock.MagicMock):
+    def test_should_handle_none_auth(self):
         props = {"host": "test"}
-        try:
-            sdk_api = SdkApi(props, self.default_url)
-        except Exception:
-            mock_logger_error.assert_called()
-            self.assertIn("Authentication", mock_logger_error.call_args[0][0])
+        sdk_api = SdkApi(props, self.default_url)
+        self.assertEqual(sdk_api.session.password, None)
+
+    def test_should_handle_cert_auth(self):
+        props = self.cert_props
+        sdk_api = SdkApi(props, self.default_url)
+        self.assertEqual(sdk_api.session.cert, self.cert_props["cert"])
+        self.assertEqual(sdk_api.session.certKey, self.cert_props["certKey"])
 
     def test_should_handle_basic_auth(self):
         """Created object should handle basic authentication."""


### PR DESCRIPTION
**What It Does**
Supports for `AUTH_TYPE_CERT_PEM` and `AUTH_TYPE_NONE` in `session` addressed in [#291] and [#296]

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->