### PR TITLE
Fix audit workflow and revert Secrets SDK version

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -15,7 +15,14 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
-    - name: Check Vulnerabilities
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Check Python Vulnerabilities
       uses: pypa/gh-action-pip-audit@v1.1.0
       with:
         inputs: requirements.txt docs/requirements.txt
+
+    - name: Check Secrets SDK Vulnerabilities
+      working-directory: src/secrets
+      run: cargo audit --deny warnings

--- a/.github/workflows/sdk-release.yaml
+++ b/.github/workflows/sdk-release.yaml
@@ -50,9 +50,9 @@ jobs:
           with open(os.environ["GITHUB_OUTPUT"], 'a') as f:
             print("version=" + ("-".join(new_version.rsplit(".", 1)) if new_version.count(".") > 2 else new_version), file=f)
 
-      - name: Update version (cargo)
-        run: cargo install cargo-edit && cargo set-version ${{ steps.update-version.outputs.version }}
-        working-directory: src/secrets
+      # - name: Update version (cargo)
+      #   run: cargo install cargo-edit && cargo set-version ${{ steps.update-version.outputs.version }}
+      #   working-directory: src/secrets
 
       - name: Update version (git)
         run: git add src/_version.py src/secrets/Cargo.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ pydoclint==0.5.3
 pyfakefs
 pylama==7.7.1
 pylint==3.2.5
-pytest==7.1.2
+pytest==7.4.4
 python-decouple==3.4
 PyYAML==6.0.1
 requests==2.32.0

--- a/src/secrets/Cargo.lock
+++ b/src/secrets/Cargo.lock
@@ -241,7 +241,7 @@ checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
 
 [[package]]
 name = "keyring"
-version = "1.0.0-dev21"
+version = "1.0.0-dev12"
 dependencies = [
  "pyo3",
  "secrets_core",

--- a/src/secrets/Cargo.toml
+++ b/src/secrets/Cargo.toml
@@ -2,7 +2,7 @@
 name = "keyring"
 readme = "README.md"
 repository = "https://github.com/zowe/zowe-client-python-sdk"
-version = "1.0.0-dev21"
+version = "1.0.0-dev12"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
* Adds cargo audit for Secrets SDK
* Reverts Secrets SDK version to last published one
* Updates `pytest` dev dep for technical currency

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->