### PR TITLE
Prefer older version of jsonschema without Rust dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the Zowe Client Python SDK will be documented in this file.
 
+## Recent Changes
+
+### Bug Fixes
+
+- Downgraded the `jsonschema` dependency of the Core SDK for Python versions older than 3.14 to remove Rust dependency. [#390](https://github.com/zowe/zowe-client-python-sdk/pull/390)
+- Updated the `requests` dependency of the Core SDK for technical currency. [#390](https://github.com/zowe/zowe-client-python-sdk/pull/390)
+
 ## `1.0.0-dev25`
 
 - Support responseTimeout profile property for z/OSMF operations. [#369](https://github.com/zowe/zowe-client-python-sdk/pull/369)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ that can interact with z/OS components.
 
 ## Installation
 
+> [!WARNING]
+> On z/OS USS, Python 3.14 and newer are not supported due to missing Rust build tools. For details, see [#388](https://github.com/zowe/zowe-client-python-sdk/issues/388).
+
 When installing the Zowe Client Python SDK, you have two options:
 
 - Install all the Zowe packages

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ that can interact with z/OS components.
 ## Installation
 
 > [!WARNING]
-> On z/OS USS, Python 3.14 and newer are not supported due to missing Rust build tools. For details, see [#388](https://github.com/zowe/zowe-client-python-sdk/issues/388).
+> On z/OS USS, Python 3.14 and newer versions are not supported due to missing Rust build tools. For details, see [#388](https://github.com/zowe/zowe-client-python-sdk/issues/388).
 
 When installing the Zowe Client Python SDK, you have two options:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 deepmerge==1.1.0
 json5==0.12.1
-jsonschema==4.25.1
+jsonschema==4.17.3
 PyYAML==6.0.1
 requests==2.32.4
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 deepmerge==1.1.0
 json5==0.12.1
-jsonschema==4.17.3
+jsonschema==4.25.1
 PyYAML==6.0.1
 requests==2.32.4
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ deepmerge==1.1.0
 json5==0.12.1
 jsonschema==4.25.1
 PyYAML==6.0.1
-requests==2.32.4
+requests==2.33.0
 
 # Dev deps
 setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 deepmerge==1.1.0
 json5==0.12.1
-jsonschema==4.25.1
+jsonschema==4.17.3; python_version<'3.14'
+jsonschema==4.25.1; python_version>='3.14'
 PyYAML==6.0.1
 requests==2.33.0
 

--- a/src/core/setup.py
+++ b/src/core/setup.py
@@ -40,9 +40,9 @@ setup(
         "jsonschema~=4.17.3; python_version<'3.14'",
         "jsonschema~=4.25.1; python_version>='3.14'",
         "pyyaml~=6.0.1",
-        "requests~=2.32.0",
+        "requests~=2.33.0",
         # Pin urllib3 to the same version range that `requests` uses
-        "urllib3>=1.21.1,<3",
+        "urllib3>=1.26,<3",
     ],
     extras_require={"secrets": [resolve_sdk_dep("secrets", "~=1.0.0.dev")]},
     packages=find_namespace_packages(include=["zowe.*"]),

--- a/src/core/setup.py
+++ b/src/core/setup.py
@@ -36,7 +36,7 @@ setup(
     install_requires=[
         "deepmerge~=1.1.0",
         "json5~=0.12.1",
-        "jsonschema~=4.25.1",
+        "jsonschema~=4.17.3",
         "pyyaml~=6.0.1",
         "requests~=2.32.0",
         "urllib3>=1.21.1,<3",  # Same version range that `requests` uses

--- a/src/core/setup.py
+++ b/src/core/setup.py
@@ -36,10 +36,13 @@ setup(
     install_requires=[
         "deepmerge~=1.1.0",
         "json5~=0.12.1",
-        "jsonschema~=4.17.3",
+        # Prefer older version of jsonschema without Rust dependency
+        "jsonschema~=4.17.3; python_version<'3.14'",
+        "jsonschema~=4.25.1; python_version>='3.14'",
         "pyyaml~=6.0.1",
         "requests~=2.32.0",
-        "urllib3>=1.21.1,<3",  # Same version range that `requests` uses
+        # Pin urllib3 to the same version range that `requests` uses
+        "urllib3>=1.21.1,<3",
     ],
     extras_require={"secrets": [resolve_sdk_dep("secrets", "~=1.0.0.dev")]},
     packages=find_namespace_packages(include=["zowe.*"]),


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
<!-- **Does this close any currently open issues?**
If this PR closes an issue, please uncomment the line below and include the issue number.
Fixes #(issue_number) -->
Partially addresses https://github.com/zowe/zowe-client-python-sdk/issues/388.

`jsonschema` 4.18.0 replaced a pure C dep with a Rust-based one that is uninstallable on z/OS - see https://github.com/python-jsonschema/jsonschema/issues/1117.

Downgrading `jsonschema` to 4.17.3 resolves the dependency issue, but is not supported in Py3.14 and above.

Until we have time in the future to investigate a replacement for `jsonschema`, the best solution seems to be making the `jsonschema` version conditional based on Python version, and documenting that Py3.14 is not supported on z/OS.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
Audit check is failing on `pygments` which is a dev dep used for building docs and has no published fix yet.