### PR TITLE
get_log_messages console REST API function, other enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the Zowe Client Python SDK will be documented in this file.
 
+## Recent Changes
+
+### Enhancements
+- Added get_log_messages console REST API function. [#391](https://github.com/zowe/zowe-client-python-sdk/pull/391)
+- Added exec-data and status query parameters to list_jobs. [#391](https://github.com/zowe/zowe-client-python-sdk/pull/391)
+- Corrected members parsing, list_members enhancement. [#391](https://github.com/zowe/zowe-client-python-sdk/pull/391)
+
 ## `1.0.0-dev26`
 
 ### Bug Fixes

--- a/src/core/zowe/core_for_zowe_sdk/request_handler.py
+++ b/src/core/zowe/core_for_zowe_sdk/request_handler.py
@@ -10,11 +10,11 @@ SPDX-License-Identifier: EPL-2.0
 Copyright Contributors to the Zowe Project.
 """
 
-from typing import Union, Any
-from requests import Response
+from typing import Any, Union
 
 import requests
 import urllib3
+from requests import Response
 
 from .exceptions import InvalidRequestMethod, RequestFailed, UnexpectedStatus
 from .logger import Log
@@ -115,27 +115,23 @@ class RequestHandler:
         ------
         UnexpectedStatus
             If the response status code is not in the expected code list
-        RequestFailed
-            If the HTTP/HTTPS request fails
         """
-        # Automatically checks if status code is between 200 and 400
-        if self.__response.ok:
-            if self.__response.status_code not in self.__expected_code:
-                self.__logger.error(
-                    f"The status code from z/OSMF was: {self.__expected_code}\n"
-                    f"Expected: {self.__response.status_code}\n"
-                    f"Request output: {self.__response.text}"
-                )
-                raise UnexpectedStatus(self.__expected_code, self.__response.status_code, self.__response.text)
+        if self.__response.status_code in self.__expected_code:
+            return
         else:
-            output_str = str(self.__response.request.url)
-            output_str += "\n" + str(self.__response.request.headers)
-            output_str += "\n" + str(self.__response.request.body)
-            output_str += "\n" + str(self.__response.text)
-            self.__logger.error(
-                f"HTTP Request has failed with status code {self.__response.status_code}. \n {output_str}"
+            diagnostics = (
+                f"The status code from z/OSMF was: {self.__response.status_code}\n"
+                f"Expected: {self.__expected_code}\n"
+                f"Request URL: {self.__response.request.url}\n"
+                f"Request headers: {self.__response.request.headers}\n"
+                f"Request body: {self.__response.request.body}\n"
+                f"Request output: {self.__response.text}"
             )
-            raise RequestFailed(self.__response.status_code, output_str)
+            if self.__response.ok:
+                self.__logger.warning(diagnostics)
+            else:
+                self.__logger.error(diagnostics)
+                raise UnexpectedStatus(self.__expected_code, self.__response.status_code, self.__response.text)     
 
     def __normalize_response(self) -> Union[str, bytes, dict[str, Any], None]:
         """

--- a/src/zos_console/zowe/zos_console_for_zowe_sdk/console.py
+++ b/src/zos_console/zowe/zos_console_for_zowe_sdk/console.py
@@ -10,11 +10,17 @@ SPDX-License-Identifier: EPL-2.0
 Copyright Contributors to the Zowe Project.
 """
 
-from typing import Optional, Any
+from datetime import datetime, timezone
+from typing import Any, Literal, Optional
 
 from zowe.core_for_zowe_sdk import SdkApi
 
-from .response import ConsoleResponse, IssueCommandResponse
+from .response import (
+    ConsoleResponse,
+    GetLogMessagesResponse,
+    IssueCommandResponse,
+    UnsuccessfulGetLogMessagesResponse,
+)
 
 
 class Console(SdkApi):  # type: ignore
@@ -30,9 +36,14 @@ class Console(SdkApi):  # type: ignore
     """
 
     def __init__(self, connection: dict[str, Any], log: bool = True):
-        super().__init__(connection, "/zosmf/restconsoles/consoles/defcn", logger_name=__name__, log=log)
+        super().__init__(connection, "/zosmf/restconsoles/", logger_name=__name__, log=log)
 
-    def issue_command(self, command: str, console: Optional[str] = None) -> IssueCommandResponse:
+    def issue_command(
+        self,
+        command: str,
+        console: Optional[str] = None,
+        system: Optional[str] = None
+    ) -> IssueCommandResponse:
         """Issues a command on z/OS Console.
 
         Parameters
@@ -41,6 +52,9 @@ class Console(SdkApi):  # type: ignore
             The z/OS command to be executed
         console : Optional[str]
             Name of the console that should be used to execute the command (default is None)
+        system : Optional[str]
+            Name of the system in the same sysplex that the command is routed to
+            (default is None, that means the local system)
 
         Returns
         -------
@@ -48,8 +62,10 @@ class Console(SdkApi):  # type: ignore
             A JSON containing the response from the console command
         """
         custom_args = self._create_custom_request_arguments()
-        custom_args["url"] = self._request_endpoint.replace("defcn", console or "defcn")
-        request_body = {"cmd": command}
+        custom_args["url"] = "{}consoles/{}".format(self._request_endpoint, console or "defcn")
+        request_body = {"cmd":command}
+        if system is not None:
+            request_body["system"] = system
         custom_args["json"] = request_body
         response_json = self.request_handler.perform_request("PUT", custom_args)
         return IssueCommandResponse(response_json)
@@ -71,7 +87,88 @@ class Console(SdkApi):  # type: ignore
             A JSON containing the response to the command
         """
         custom_args = self._create_custom_request_arguments()
-        request_url = "{}/solmsgs/{}".format(console or "defcn", response_key)
-        custom_args["url"] = self._request_endpoint.replace("defcn", request_url)
+        request_url = "{}consoles/{}/solmsgs/{}".format(self._request_endpoint, console or "defcn", response_key)
+        custom_args["url"] = request_url
         response_json = self.request_handler.perform_request("GET", custom_args)
         return ConsoleResponse(response_json)
+    
+    def get_log_messages(
+        self,
+        time: Optional[datetime] = None,
+        timestamp: Optional[int] = None,
+        time_range: Optional[str] = None,
+        hardcopy: Optional[Literal["OPERLOG", "SYSLOG"]] = None,
+        sys_name: Optional[str] = None,
+        direction: Optional[Literal["backward", "forward"]] = None
+    ) -> GetLogMessagesResponse | UnsuccessfulGetLogMessagesResponse:
+        """
+        Retrieve messages from hardcopy logs on the system.
+        
+        The maximum return size of the log is 10000.
+        If more than 10000 logs exist in the timeframe, the system returns the first 10000 logs.
+
+        See more at: `Get messages from a hardcopy log`_
+        .. _Get messages from a hardcopy log:
+           https://www.ibm.com/docs/en/zos/3.2.0?topic=services-get-messages-from-hardcopy-log
+        
+        Parameters
+        ----------
+        time : Optional[datetime]
+            Specifies when z/OSMF starts to retrieve messages.
+            This value is used if the timestamp parameter is not specified.
+        timestamp : Optional[int]
+            Specifies the UNIX timestamp, which is the number of milliseconds since 1970-01-01 UTC.
+            This parameter is specified, the "time" parameter is ignored.
+        time_range : Optional[str]
+            Specifies the time range for which the log is to be retrieved.
+            Supported time units include s, m, and h for seconds, minutes, and hours.
+            The format is nnnu, where nnn is a number 1-999 and u is one of the time units "s", "m", or "h".
+            For example, 999s of 20m.
+            The default is 10m.
+        hardcopy : Optional[Literal['OPERLOG', 'SYSLOG']]
+            Specify the source where the logs come from.
+            If not specified, the API tries OPERLOG first.
+            If the OPERLOG is not enabled on the system, the API returns the SYSLOG.
+        sys_name : Optional[str]
+            The name of the system on which the SYSLOG resides.
+        direction : Optional[Literal['backward', 'forward']]
+            Specifies the direction (from a specified time) in which messages are retrieved.
+            The default is "backward", meaning that messages are retrieved backward from the specified time.
+
+        Returns
+        -------
+        GetLogMessagesResponse | UnsuccessfulGetLogMessagesResponse
+            A response content for a successful/unsuccessful get messages request response
+        """
+        custom_args = self._create_custom_request_arguments()
+        custom_args["url"] = "{}v1/log".format(self._request_endpoint)
+        params = {}
+        if time is not None and timestamp is not None:
+            self.logger.warning(
+                'Both "time" and "timestamp" query parameters are provided. "time" parameter is ignored'
+            )
+            time = None
+        if time is not None:
+            if time.tzinfo is not None and time.tzinfo != timezone.utc:
+                self.logger.warning(
+                    f'"time" query parameter is not in UTC timezone ({time.tzinfo}). Conversion to UTC will occur'
+                )
+                time = time.astimezone(timezone.utc)
+            params["time"] = time
+        if timestamp:
+            params["timestamp"] = timestamp
+        if time_range:
+            params["timeRange"] = time_range
+        if hardcopy:
+            params["hardcopy"] = hardcopy
+        if sys_name:
+            params["sysName"] = sys_name
+        if direction:
+            params["direction"] = direction
+        custom_args["params"] = params
+        response_json = self.request_handler.perform_request("GET", custom_args, expected_code=[200, 400, 500])
+        return (
+            GetLogMessagesResponse(response_json)
+            if "returnCode" not in response_json.keys()
+            else UnsuccessfulGetLogMessagesResponse(response_json)
+        )

--- a/src/zos_console/zowe/zos_console_for_zowe_sdk/response/__init__.py
+++ b/src/zos_console/zowe/zos_console_for_zowe_sdk/response/__init__.py
@@ -10,4 +10,9 @@ SPDX-License-Identifier: EPL-2.0
 Copyright Contributors to the Zowe Project.
 """
 
-from .console import ConsoleResponse, IssueCommandResponse
+from .console import (
+    ConsoleResponse,
+    GetLogMessagesResponse,
+    IssueCommandResponse,
+    UnsuccessfulGetLogMessagesResponse,
+)

--- a/src/zos_console/zowe/zos_console_for_zowe_sdk/response/console.py
+++ b/src/zos_console/zowe/zos_console_for_zowe_sdk/response/console.py
@@ -10,8 +10,30 @@ SPDX-License-Identifier: EPL-2.0
 Copyright Contributors to the Zowe Project.
 """
 
+import re
 from dataclasses import dataclass
+from datetime import datetime, timedelta
+from datetime import timezone as tz
 from typing import Any, Optional
+
+CAMEL_TO_SNAKE_CASE_PATTERN = re.compile(r'(?<!^)(?=[A-Z])')
+
+
+def to_snake_case(src_str: str) -> str:
+    """
+    Convert camel case string (cameCaseString) to a snake case string (snake_case_string).
+
+    Parameters
+    ----------
+    src_str : str
+        The string to convert
+
+    Returns
+    -------
+    str
+        The converted string
+    """
+    return CAMEL_TO_SNAKE_CASE_PATTERN.sub('_', src_str).lower()
 
 
 @dataclass
@@ -48,3 +70,139 @@ class ConsoleResponse:
 
     def __setitem__(self, key: str, value: Any) -> None:
         self.__dict__[key.replace("-", "_")] = value
+
+
+@dataclass
+class LogMessageResponse:
+    """
+    Log message response object.
+    See more at [Messages JSON object](https://www.ibm.com/docs/en/zos/3.2.0?topic=services-get-messages-from-hardcopy-log#IZUHPINFO_API_GetMessagesandLogs.dita__table_qby_q2x_ypb)
+
+    Parameters
+    ----------
+    cart : Optional[str]
+        Eight character command and response token (CART).
+    color : Optional[str]
+        The color of the message.
+    job_name : Optional[str]
+        The name of the job that generates the message.
+    message : Optional[str]
+        The content of the message.
+    message_id : Optional[str]
+        The message ID.
+    reply_id : Optional[str]
+        Reply ID, in decimal.
+    system : Optional[str]
+        Original eight character system name.
+    type : Optional[str]
+        HARDCOPY.
+    sub_type : Optional[str]
+        Indicate whether the message is a DOM, WTOR, or HOLD message.
+    time : Optional[datetime]
+        For example, “Thu Feb 03 03:00 GMT 2021”.
+    timestamp : Optional[int]
+        UNIX timestamp (milliseconds since epoch). For example, 1621920830109.
+    """
+    
+    cart: Optional[str] = None
+    color: Optional[str] = None
+    job_name: Optional[str] = None
+    message: Optional[str] = None
+    message_id: Optional[str] = None
+    reply_id: Optional[str] = None
+    system: Optional[str] = None
+    type: Optional[str] = None
+    sub_type: Optional[str] = None
+    time: Optional[datetime] = None
+    timestamp: Optional[int] = None
+
+    def __init__(self, raw_data: dict[str, Any]) -> None:
+        for raw_key, raw_value in raw_data.items():
+            key = to_snake_case(raw_key)
+            match(key):
+                case "time":
+                    value = datetime.strptime(raw_value, "%a %b %d %H:%M:%S %Z %Y")
+                case _:
+                    value = raw_value
+            super().__setattr__(key, value)
+    
+    def __getitem__(self, key: str) -> Any:
+        return self.__dict__[to_snake_case(key)]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.__dict__[to_snake_case(key)] = value
+
+
+@dataclass
+class GetLogMessagesResponse:
+    """
+    Get log messages response object.
+    See more at [Response content for a successful Get Messages request](https://www.ibm.com/docs/en/zos/3.2.0?topic=services-get-messages-from-hardcopy-log#IZUHPINFO_API_GetMessagesandLogs.dita__getcmdresponse)
+
+    Parameters
+    ----------
+    timezone : Optional[tz]
+        The timezone of the z/OS system.
+    total_items : Optional[int]
+        Total number of messages returned in the response.
+    next_timestamp : Optional[int]
+        The UNIX timestamp (milliseconds).
+    items : Optional[list[LogMessageResponse]]
+        Array of log messages.
+    source : Optional[str]
+        Indicates the source of the messages.
+    """
+    timezone: Optional[tz] = None
+    total_items: Optional[int] = None
+    next_timestamp: Optional[int] = None
+    items: Optional[list[LogMessageResponse]] = None
+    source: Optional[str] = None
+    
+    def __init__(self, response: dict[str, Any]) -> None:
+        for raw_key, raw_value in response.items():
+            key = to_snake_case(raw_key)
+            match(key):
+                case "timezone":
+                    value = tz(timedelta(hours=raw_value if raw_value is not None else 0))
+                case "items":
+                    value = [LogMessageResponse(x) for x in raw_value] if not raw_value == None else None
+                case _:
+                    value = raw_value
+            super().__setattr__(key, value)
+
+    def __getitem__(self, key: str) -> Any:
+        return self.__dict__[to_snake_case(key)]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.__dict__[to_snake_case(key)] = value
+
+
+@dataclass
+class UnsuccessfulGetLogMessagesResponse:
+    """
+    Get log messages response object for an unsuccessful request.
+    See more at [Response content for an unsuccessful Get Messages request](https://www.ibm.com/docs/en/zos/3.2.0?topic=services-get-messages-from-hardcopy-log#IZUHPINFO_API_GetMessagesandLogs.dita__table_b2g_sgx_ypb)
+
+    Parameters
+    ----------
+    return_code : Optional[int]
+        Identifies the category of error.
+    reason_code : Optional[int]
+        Identifies the specific error.
+    reason : Optional[str]
+        Text that describes the cause of the error.
+    """
+    return_code: Optional[int] = None
+    reason_code: Optional[int] = None
+    reason: Optional[str] = None
+    
+    def __init__(self, response: dict[str, Any]) -> None:
+        for raw_key, value in response.items():
+            key = to_snake_case(raw_key)
+        super().__setattr__(key, value)
+
+    def __getitem__(self, key):
+        return self.__dict__[to_snake_case(key)]
+    
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.__dict__[to_snake_case(key)] = value

--- a/src/zos_console/zowe/zos_console_for_zowe_sdk/response/console.py
+++ b/src/zos_console/zowe/zos_console_for_zowe_sdk/response/console.py
@@ -199,7 +199,7 @@ class UnsuccessfulGetLogMessagesResponse:
     def __init__(self, response: dict[str, Any]) -> None:
         for raw_key, value in response.items():
             key = to_snake_case(raw_key)
-        super().__setattr__(key, value)
+            super().__setattr__(key, value)
 
     def __getitem__(self, key):
         return self.__dict__[to_snake_case(key)]

--- a/src/zos_files/zowe/zos_files_for_zowe_sdk/datasets.py
+++ b/src/zos_files/zowe/zos_files_for_zowe_sdk/datasets.py
@@ -11,7 +11,7 @@ Copyright Contributors to the Zowe Project.
 """
 
 import os
-from typing import Any, Optional, Union
+from typing import Any, Literal, Optional, Union
 
 from requests import Response
 from zowe.core_for_zowe_sdk import SdkApi
@@ -205,19 +205,16 @@ class DatasetOption:
         return self.__recfm
 
     @recfm.setter
-    def recfm(self, recfm: Optional[str]) -> None:
+    def recfm(self, recfm: Optional[Literal["F", "FB", "V", "VB", "U", "FBA", "FBM", "VBA", "VBM"]]) -> None:
         """Set the record format."""
-        if recfm is None:
-            if self.like is not None:
-                self.__recfm = None
-            else:
-                self.__recfm = "F"
-        elif recfm not in ("F", "FB", "V", "VB", "U", "FBA", "FBM", "VBA", "VBM"):
-            raise KeyError(
-                "'recfm' must be one of the following: 'F', 'FB', 'V', 'VB', 'U', 'FBA', 'FBM', 'VBA', 'VBM'"
-            )
-        else:
+        if recfm is not None:
+            if recfm not in ("F", "FB", "V", "VB", "U", "FBA", "FBM", "VBA", "VBM"):
+                raise KeyError(
+                    "'recfm' must be one of the following: 'F', 'FB', 'V', 'VB', 'U', 'FBA', 'FBM', 'VBA', 'VBM'"
+                )
             self.__recfm = recfm
+        else:
+            self.__recfm = None if self.like is not None else "F"
 
     @property
     def blksize(self) -> Optional[int]:
@@ -345,7 +342,7 @@ class Datasets(BaseFilesApi):  # type: ignore[misc]
         member_pattern: Optional[str] = None,
         member_start: Optional[str] = None,
         limit: int = 1000,
-        attributes: str = "member",
+        attributes: Literal["member", "base", "member,total", "base,total"] = "member",
     ) -> MemberListResponse:
         """
         Retrieve the list of members on a given PDS/PDSE.
@@ -360,8 +357,8 @@ class Datasets(BaseFilesApi):  # type: ignore[misc]
             The starting point for listing members
         limit: int
             The maximum number of members returned
-        attributes: str
-            The member attributes to retrieve
+        attributes: Literal['member', 'base', 'member,total', 'base,total'], optional
+            The member attributes to retrieve ("member" by default which means that only member names to be returned)
 
         Returns
         -------
@@ -379,7 +376,7 @@ class Datasets(BaseFilesApi):  # type: ignore[misc]
         custom_args["headers"]["X-IBM-Max-Items"] = "{}".format(limit)
         custom_args["headers"]["X-IBM-Attributes"] = attributes
         response_json = self.request_handler.perform_request("GET", custom_args)
-        return MemberListResponse(response_json, (attributes == "base"))
+        return MemberListResponse(response_json, "base" in attributes)
 
     def copy_data_set_or_member(
         self,
@@ -476,11 +473,18 @@ class Datasets(BaseFilesApi):  # type: ignore[misc]
                         self.logger.error("Can't allocate empty directory blocks.")
                         raise ValueError
         else:
-            dsn_attr = self.list(options.like, return_attributes=True)["items"]
-            for dsn in dsn_attr:
-                if dsn["dsname"] == options.like.upper():
-                    options.blksize = int(dsn["blksz"])
-                    break
+            ds_items = self.list(options.like, return_attributes=True).items
+            if ds_items is not None:
+                if len(ds_items) > 0:
+                    dsn_attr = next((ds_item for ds_item in ds_items if ds_item.dsname.upper() == options.like.upper()), None)
+                    if dsn_attr is not None:
+                        options.blksize = int(dsn_attr.blksz)
+                    else:
+                        raise ValueError(f"Model dataset {options.like.upper()} is not found.")
+                else:
+                    raise ValueError(f"Model dataset {options.like.upper()} is not found.")
+            else:
+                raise ValueError("Could not fetch data set attributes of the model data set.")
 
         custom_args = self._create_custom_request_arguments()
         custom_args["url"] = "{}ds/{}".format(self._request_endpoint, self._encode_uri_component(dataset_name))

--- a/src/zos_files/zowe/zos_files_for_zowe_sdk/response/datasets.py
+++ b/src/zos_files/zowe/zos_files_for_zowe_sdk/response/datasets.py
@@ -86,10 +86,25 @@ class MemberListResponse:
     def __init__(self, response: dict[str, Any], attributes: bool) -> None:
         for key, value in response.items():
             if key == "items":
-                value = (
-                    [MemberResponse(**x) for x in value] if attributes else [SimpleMemberResponse(**x) for x in value]
-                )
-            super().__setattr__(key, value)
+                raw_members_list: list[dict[str, Any]] = value
+                if not attributes:
+                    members_list = [SimpleMemberResponse(**raw_mem_props) for raw_mem_props in raw_members_list]
+                elif len(raw_members_list) != 0:
+                    has_undef_recfm_members = False
+                    for next_member in raw_members_list:
+                        if "ac" in next_member.keys():
+                            has_undef_recfm_members = True
+                            break
+                    members_list = (
+                        [UndefRecfmMemberResponse(raw_mem_props) for raw_mem_props in raw_members_list]
+                        if has_undef_recfm_members
+                        else [MemberResponse(**raw_mem_props) for raw_mem_props in raw_members_list]
+                    )
+                else:
+                    members_list = []
+                super().__setattr__(key, members_list)
+            else:
+                super().__setattr__(key, value)
 
     def __getitem__(self, key: str) -> Any:
         return self.__dict__[key]
@@ -129,3 +144,27 @@ class MemberResponse:
 
     def __setitem__(self, key: str, value: Any) -> None:
         self.__dict__[key] = value
+
+
+@dataclass
+class UndefRecfmMemberResponse:
+    """https://www.ibm.com/docs/en/zos/3.2.0?topic=zdsfri-json-document-specifications-zos-data-set-file-rest-interface-requests#RESTFILES_JSONDocumentSpecifications__pdsUkeypairs"""
+    member: Optional[str] = None
+    ac: Optional[str] = None
+    alias_of: Optional[str] = None
+    amode: Optional[str] = None
+    rmode: Optional[str] = None
+    size: Optional[str] = None
+    ttr: Optional[str] = None
+    ssi: Optional[str] = None
+
+    def __init__(self, member_props: dict[str, Any]) -> None:
+        for k, value in member_props.items():
+            key = k.replace("-", "_")
+            super().__setattr__(key, value)
+
+    def __getitem__(self, key: str) -> Any:
+        return self.__dict__[key.replace("-", "_")]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.__dict__[key.replace("-", "_")] = value

--- a/src/zos_jobs/zowe/zos_jobs_for_zowe_sdk/jobs.py
+++ b/src/zos_jobs/zowe/zos_jobs_for_zowe_sdk/jobs.py
@@ -11,7 +11,7 @@ Copyright Contributors to the Zowe Project.
 """
 
 import os
-from typing import Optional, Any
+from typing import Any, Literal, Optional
 
 from zowe.core_for_zowe_sdk import SdkApi
 
@@ -267,6 +267,8 @@ class Jobs(SdkApi):  # type: ignore
         prefix: str = "*",
         max_jobs: int = 1000,
         user_correlator: Optional[str] = None,
+        fetch_exec_data: bool = False,
+        status: Literal["ACTIVE", "INACTIVE", "ALL"] = "ALL"
     ) -> list[JobResponse]:
         """
         Retrieve list of jobs on JES based on the provided arguments.
@@ -281,6 +283,10 @@ class Jobs(SdkApi):  # type: ignore
             The maximum number of jobs in the output (default is 1000)
         user_correlator: Optional[str]
             The z/OSMF user correlator attribute (default is None)
+        fetch_exec_data: bool, optional
+            The flag to indicate whether 'exec-data' is to be returned for the jobs (default is False)
+        status: Literal['ACTIVE', 'INACTIVE', 'ALL'], optional
+            The status of the jobs to be listed (default is "ALL", which means to fetch both active and inactive jobs)
 
         Returns
         -------
@@ -293,6 +299,10 @@ class Jobs(SdkApi):  # type: ignore
             params["owner"] = owner
         if user_correlator:
             params["user-correlator"] = user_correlator
+        if fetch_exec_data:
+            params["exec-data"] = "Y"
+        if status != "ALL":
+            params["status"] = status
         custom_args["params"] = params
         response_json = self.request_handler.perform_request("GET", custom_args)
         response = []

--- a/src/zos_jobs/zowe/zos_jobs_for_zowe_sdk/response/jobs.py
+++ b/src/zos_jobs/zowe/zos_jobs_for_zowe_sdk/response/jobs.py
@@ -11,6 +11,7 @@ Copyright Contributors to the Zowe Project.
 """
 
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any, Optional
 
 
@@ -29,13 +30,25 @@ class JobResponse:
     jobname: Optional[str] = None
     status: Optional[str] = None
     retcode: Optional[str] = None
+    exec_system: Optional[str] = None
+    exec_member: Optional[str] = None
+    exec_submitted: Optional[datetime] = None
+    exec_started: Optional[datetime] = None
+    exec_ended: Optional[datetime] = None
 
     def __init__(self, response: dict[str, Any]) -> None:
         for k, value in response.items():
             key = k.replace("-", "_")
             if key == "class":
                 key = "job_class"
-            super().__setattr__(key, value)
+            if key in ["exec_submitted", "exec_started", "exec_ended"]:
+                try:
+                    date_and_time = datetime.fromisoformat(value.replace("Z", "+00:00"))
+                except (ValueError, AttributeError):
+                    date_and_time = None
+                super().__setattr__(key, date_and_time)
+            else:
+                super().__setattr__(key, value)
 
     def __getitem__(self, key: str) -> Any:
         if key == "class":

--- a/tests/unit/core/test_request_handler.py
+++ b/tests/unit/core/test_request_handler.py
@@ -46,6 +46,18 @@ class TestRequestHandlerClass(unittest.TestCase):
             mock_logger_error.assert_called_once()
             self.assertIn("The status code", mock_logger_error.call_args[0][0])
 
+    @mock.patch("logging.Logger.warning")
+    @mock.patch("requests.Session.request")
+    def test_logger_unmatched_status_code_ok(self, mock_send_request, mock_logger_warning: mock.MagicMock):
+        """Test logger with unexpected status code, but the code is OK"""
+        mock_send_request.return_value = mock.Mock(ok=True, status_code=210)
+        request_handler = RequestHandler(self.session_arguments)
+        try:
+            request_handler.perform_request("GET", {"url": "https://www.zowe.org"}, stream=True)
+        except exceptions.UnexpectedStatus:
+            mock_logger_warning.assert_called_once()
+            self.assertIn("The status code", mock_logger_warning.call_args[0][0])
+
     @mock.patch("logging.Logger.error")
     def test_logger_perform_request_invalid_method(self, mock_logger_error: mock.MagicMock):
         """Test logger with invalid request method"""
@@ -57,15 +69,15 @@ class TestRequestHandlerClass(unittest.TestCase):
             self.assertIn("Invalid HTTP method input", mock_logger_error.call_args[0][0])
 
     @mock.patch("logging.Logger.error")
-    @mock.patch("requests.Session.send")
+    @mock.patch("requests.Session.request")
     def test_logger_invalid_status_code(self, mock_send_request, mock_logger_error: mock.MagicMock):
-        mock_send_request.return_value = mock.Mock(ok=False)
+        mock_send_request.return_value = mock.Mock(ok=True, status_code=12345)
         request_handler = RequestHandler(self.session_arguments)
         try:
             request_handler.perform_request("GET", {"url": "https://www.zowe.org"}, stream=True)
-        except exceptions.RequestFailed:
+        except exceptions.UnexpectedStatus:
             mock_logger_error.assert_called_once()
-            self.assertIn("HTTP Request has failed", mock_logger_error.call_args[0][0])
+            self.assertIn("The status code", mock_logger_error.call_args[0][0])
         mock_logger_error.assert_called_once
 
     @mock.patch("requests.Session.send")

--- a/tests/unit/files/datasets/test_create.py
+++ b/tests/unit/files/datasets/test_create.py
@@ -42,6 +42,110 @@ class TestCreateClass(TestCase):
         Files(self.test_profile).create_data_set("DSNAME123", options=option)
         self.assertEqual(mock_send_request.call_count, 2)
 
+    @mock.patch("logging.Logger.error")
+    @mock.patch("requests.Session.send")
+    def test_create_data_set_po_empty_dirblk(self, mock_send_request, mock_logger_error: mock.MagicMock):
+        """Test if create PO dataset does not send request when dirblk is 0"""
+        mock_send_request.return_value = mock.Mock(headers={"Content-Type": "application/json"}, status_code=201)
+        with self.assertRaises(ValueError):
+            option = DatasetOption(dsorg="PO", lrecl=80, recfm="FB", primary=1, dirblk=0)
+            Files(self.test_profile).create_data_set("DSNAME124", options=option)
+            mock_logger_error.assert_called_once()
+            self.assertIn("Can't allocate empty directory blocks.", mock_logger_error.call_args[0][0])
+            mock_send_request.assert_not_called()
+
+    @mock.patch("requests.Session.send")
+    def test_create_data_set_po_dirblk_not_specified(self, mock_send_request):
+        """Test if create PO dataset does not send request when dirblk is 0"""
+        mock_send_request.return_value = mock.Mock(headers={"Content-Type": "application/json"}, status_code=201)
+        option = DatasetOption(dsorg="PO", lrecl=80, recfm="FB", primary=1)
+        Files(self.test_profile).create_data_set("DSNAME125", options=option)
+        mock_send_request.assert_called()
+
+    @mock.patch("logging.Logger.error")
+    @mock.patch("requests.Session.send")
+    def test_create_data_set_po_empty_dirblk(self, mock_send_request, mock_logger_error: mock.MagicMock):
+        """Test if create PO dataset sends request when dirblk is not specified"""
+        mock_send_request.return_value = mock.Mock(headers={"Content-Type": "application/json"}, status_code=201)
+        with self.assertRaises(ValueError):
+            option = DatasetOption(dsorg="PO", lrecl=80, recfm="FB", primary=1, dirblk=0)
+            Files(self.test_profile).create_data_set("DSNAME126", options=option)
+            mock_logger_error.assert_called_once()
+            self.assertIn("Can't allocate empty directory blocks.", mock_logger_error.call_args[0][0])
+            mock_send_request.assert_not_called()
+
+    @mock.patch("logging.Logger.error")
+    @mock.patch("requests.Session.send")
+    def test_create_data_set_ps_dirblk_specified(self, mock_send_request, mock_logger_error: mock.MagicMock):
+        """Test if create PS dataset does not send request when dirblk is specified and not 0"""
+        mock_send_request.return_value = mock.Mock(headers={"Content-Type": "application/json"}, status_code=201)
+        with self.assertRaises(ValueError):
+            option = DatasetOption(dsorg="PS", lrecl=80, recfm="FB", primary=1, dirblk=1)
+            Files(self.test_profile).create_data_set("DSNAME123", options=option)
+            mock_logger_error.assert_called_once()
+            self.assertIn("Can't allocate directory blocks for files.", mock_logger_error.call_args[0][0])
+            mock_send_request.assert_not_called()
+
+    @mock.patch("requests.Session.send")
+    def test_create_data_set_with_like_not_found(self, mock_send_request: mock.Mock):
+        """Test if create dataset does not send request to create from a model dataset when the model is not found"""
+
+        ds_name = "test"
+
+        response1 = mock.Mock(
+            headers={"Content-Type": "application/octet-stream"},
+            status_code=200,
+            content={"items": []},
+        )
+        response2 = mock.Mock(headers={"Content-Type": "application/json"}, status_code=201)
+        mock_send_request.side_effect = [response1, response2]
+
+        with self.assertRaises(ValueError) as e_info:
+            option = DatasetOption(like=ds_name)
+            Files(self.test_profile).create_data_set("DSNAME123", options=option)
+            self.assertEqual(mock_send_request.call_count, 1)
+            self.assertEqual(str(e_info.exception), f"Model dataset {ds_name.upper()} is not found.")
+
+    @mock.patch("requests.Session.send")
+    def test_create_data_set_with_like_not_returned(self, mock_send_request: mock.Mock):
+        """Test if create dataset does not send request to create from a model dataset when the model is not found, but the list of similar datasets is returned"""
+
+        ds_name = "test"
+
+        response1 = mock.Mock(
+            headers={"Content-Type": "application/octet-stream"},
+            status_code=200,
+            content={"items": [{"dsname": "test1", "blksz": 123}]},
+        )
+        response2 = mock.Mock(headers={"Content-Type": "application/json"}, status_code=201)
+        mock_send_request.side_effect = [response1, response2]
+
+        with self.assertRaises(ValueError) as e_info:
+            option = DatasetOption(like=ds_name)
+            Files(self.test_profile).create_data_set("DSNAME123", options=option)
+            self.assertEqual(mock_send_request.call_count, 1)
+            self.assertEqual(str(e_info.exception), f"Model dataset {ds_name.upper()} is not found.")
+
+    @mock.patch("requests.Session.send")
+    def test_create_data_set_with_like_items_none(self, mock_send_request: mock.Mock):
+        """Test if create dataset does not send request to create from a model dataset when the list returns incorrect response"""
+
+        ds_name = "test"
+
+        response1 = mock.Mock(
+            headers={"Content-Type": "application/octet-stream"},
+            status_code=200,
+            content={"some_attr":"test"},
+        )
+        response2 = mock.Mock(headers={"Content-Type": "application/json"}, status_code=201)
+        mock_send_request.side_effect = [response1, response2]
+
+        with self.assertRaises(ValueError) as e_info:
+            option = DatasetOption(like=ds_name)
+            Files(self.test_profile).create_data_set("DSNAME123", options=option)
+            self.assertEqual(mock_send_request.call_count, 1)
+            self.assertEqual(str(e_info.exception), f"Could not fetch data set attributes of the model data set.")
+
     def test_create_data_set_does_not_accept_invalid_recfm(self):
         """Test if create dataset raises an error for invalid record formats"""
         with self.assertRaises(KeyError):

--- a/tests/unit/files/datasets/test_create.py
+++ b/tests/unit/files/datasets/test_create.py
@@ -42,18 +42,6 @@ class TestCreateClass(TestCase):
         Files(self.test_profile).create_data_set("DSNAME123", options=option)
         self.assertEqual(mock_send_request.call_count, 2)
 
-    @mock.patch("logging.Logger.error")
-    @mock.patch("requests.Session.send")
-    def test_create_data_set_po_empty_dirblk(self, mock_send_request, mock_logger_error: mock.MagicMock):
-        """Test if create PO dataset does not send request when dirblk is 0"""
-        mock_send_request.return_value = mock.Mock(headers={"Content-Type": "application/json"}, status_code=201)
-        with self.assertRaises(ValueError):
-            option = DatasetOption(dsorg="PO", lrecl=80, recfm="FB", primary=1, dirblk=0)
-            Files(self.test_profile).create_data_set("DSNAME124", options=option)
-            mock_logger_error.assert_called_once()
-            self.assertIn("Can't allocate empty directory blocks.", mock_logger_error.call_args[0][0])
-            mock_send_request.assert_not_called()
-
     @mock.patch("requests.Session.send")
     def test_create_data_set_po_dirblk_not_specified(self, mock_send_request):
         """Test if create PO dataset does not send request when dirblk is 0"""

--- a/tests/unit/files/datasets/test_list.py
+++ b/tests/unit/files/datasets/test_list.py
@@ -3,6 +3,11 @@
 from unittest import TestCase, mock
 
 from zowe.zos_files_for_zowe_sdk import Files
+from zowe.zos_files_for_zowe_sdk.response.datasets import (
+    MemberResponse,
+    SimpleMemberResponse,
+    UndefRecfmMemberResponse,
+)
 
 
 class TestListClass(TestCase):
@@ -33,25 +38,139 @@ class TestListClass(TestCase):
             mock_send_request.assert_called()
 
     @mock.patch("requests.Session.send")
-    def test_list_members(self, mock_send_request):
-        """Test list members sends request"""
+    def test_list_members_mem_name(self, mock_send_request):
+        """Test list members sends request and receives members with member name only"""
         self.files_instance = Files(self.test_profile)
         mock_send_request.return_value = mock.Mock(headers={"Content-Type": "application/json"}, status_code=200)
-        mock_send_request.return_value.json.return_value = {"items": [{}, {}]}
+        mock_send_request.return_value.json.return_value = {
+            "items": [{"member": "TEST1"}, {"member": "TEST2"}],
+            "returnedRows":1,
+            "JSONversion":1
+        }
 
-        test_cases = [
-            ("MY.PDS", None, None, 1000, "member"),
-            ("MY.PDS", "MEM*", None, 1000, "member"),
-            ("MY.PDS", None, "MEMBER1", 1000, "member"),
-            ("MY.PDS", "MEM*", "MEMBER1", 500, "extended"),
-        ]
+        dataset_name = "TEST.PDS"
+        member_pattern = None
+        member_start = None
+        limit = 1000
+        attributes = "member"
 
-        for dataset_name, member_pattern, member_start, limit, attributes in test_cases:
-            result = self.files_instance.list_dsn_members(dataset_name, member_pattern, member_start, limit, attributes)
-            mock_send_request.assert_called()
+        result = self.files_instance.list_dsn_members(dataset_name, member_pattern, member_start, limit, attributes)
+        mock_send_request.assert_called()
 
-            prepared_request = mock_send_request.call_args[0][0]
-            self.assertEqual(prepared_request.method, "GET")
-            self.assertIn(dataset_name, prepared_request.url)
-            self.assertEqual(prepared_request.headers["X-IBM-Max-Items"], str(limit))
-            self.assertEqual(prepared_request.headers["X-IBM-Attributes"], attributes)
+        prepared_request = mock_send_request.call_args[0][0]
+        self.assertEqual(prepared_request.method, "GET")
+        self.assertIn(dataset_name, prepared_request.url)
+        self.assertEqual(prepared_request.headers["X-IBM-Max-Items"], str(limit))
+        self.assertEqual(prepared_request.headers["X-IBM-Attributes"], attributes)
+
+        self.assertEqual(len(result.items), 2)
+        self.assertTrue(isinstance(result.items[0], SimpleMemberResponse))
+        self.assertTrue(isinstance(result.items[1], SimpleMemberResponse))
+
+    @mock.patch("requests.Session.send")
+    def test_list_members_base(self, mock_send_request):
+        """Test list members sends request and receives a member with attributes"""
+        self.files_instance = Files(self.test_profile)
+        mock_send_request.return_value = mock.Mock(headers={"Content-Type": "application/json"}, status_code=200)
+        mock_send_request.return_value.json.return_value = {
+            "items": [
+                {
+                    "member":"MEMTEST",
+                    "vers":1,
+                    "mod":0,
+                    "c4date":"2015/08/12",
+                    "m4date":"2015/08/12",
+                    "cnorc":22,
+                    "inorc":22,
+                    "mnorc":0,
+                    "mtime":"05:48",
+                    "msec":"43",
+                    "user":"IBMUSER",
+                    "sclm":"N"
+                }
+            ],
+            "returnedRows":1,
+            "JSONversion":1
+        }
+
+        dataset_name = "TEST.PDS"
+        member_pattern = "MEM*"
+        member_start = None
+        limit = 1000
+        attributes = "base"
+
+        result = self.files_instance.list_dsn_members(dataset_name, member_pattern, member_start, limit, attributes)
+        mock_send_request.assert_called()
+
+        self.assertEqual(len(result.items), 1)
+        self.assertTrue(isinstance(result.items[0], MemberResponse))
+    
+    @mock.patch("requests.Session.send")
+    def test_list_members_mem_name_total(self, mock_send_request):
+        """Test list members sends request and receives members with member name only + total rows"""
+        self.files_instance = Files(self.test_profile)
+        mock_send_request.return_value = mock.Mock(headers={"Content-Type": "application/json"}, status_code=200)
+        mock_send_request.return_value.json.return_value = {
+            "items": [{"member": "MEMBER1"}, {"member": "MEMBER2"}],
+            "totalRows": 3,
+            "returnedRows":2,
+            "JSONversion":1
+        }
+
+        dataset_name = "TEST.PDS"
+        member_pattern = None
+        member_start = "MEMBER1"
+        limit = 3
+        attributes = "member,total"
+
+        result = self.files_instance.list_dsn_members(dataset_name, member_pattern, member_start, limit, attributes)
+        mock_send_request.assert_called()
+
+        self.assertEqual(len(result.items), 2)
+        self.assertTrue(isinstance(result.items[0], SimpleMemberResponse))
+        self.assertTrue(isinstance(result.items[1], SimpleMemberResponse))
+
+    @mock.patch("requests.Session.send")
+    def test_list_members_base_total(self, mock_send_request):
+        """Test list members sends request and receives undefined members + total rows"""
+        self.files_instance = Files(self.test_profile)
+        mock_send_request.return_value = mock.Mock(headers={"Content-Type": "application/json"}, status_code=200)
+        mock_send_request.return_value.json.return_value = {
+            "items": [
+                {
+                    "member": "MEMBER0",
+                    "ac": "00",
+                    "amode": "31",
+                    "attr": "RN RU",
+                    "rmode": "ANY",
+                    "size": "00008250",
+                    "ttr": "057B13"
+                }, 
+                {
+                    "member": "MEMBER1",
+                    "ac": "00",
+                    "alias-of": "SOMEXSSI",
+                    "amode": "31",
+                    "attr": "RN RU",
+                    "rmode": "ANY",
+                    "size": "0001A5F8",
+                    "ttr": "031F04"
+                }
+            ],
+            "totalRows": 5,
+            "returnedRows":2,
+            "JSONversion":1
+        }
+
+        dataset_name = "TEST.PDS"
+        member_pattern = "MEM*"
+        member_start = None
+        limit = 2
+        attributes = "base,total"
+
+        result = self.files_instance.list_dsn_members(dataset_name, member_pattern, member_start, limit, attributes)
+        mock_send_request.assert_called()
+
+        self.assertEqual(len(result.items), 2)
+        self.assertTrue(isinstance(result.items[0], UndefRecfmMemberResponse))
+        self.assertTrue(isinstance(result.items[1], UndefRecfmMemberResponse))

--- a/tests/unit/test_zos_console.py
+++ b/tests/unit/test_zos_console.py
@@ -1,9 +1,15 @@
 """Unit tests for the Zowe Python SDK z/OS Console package."""
 
 import unittest
+from datetime import datetime, timedelta, timezone
 from unittest import mock
+from unittest.mock import patch
 
 from zowe.zos_console_for_zowe_sdk import Console
+from zowe.zos_console_for_zowe_sdk.response.console import (
+    GetLogMessagesResponse,
+    UnsuccessfulGetLogMessagesResponse,
+)
 
 
 class TestConsoleClass(unittest.TestCase):
@@ -55,6 +61,21 @@ class TestConsoleClass(unittest.TestCase):
         Console(self.session_details).issue_command("TESTCMD", "TESTCNSL")
 
     @mock.patch("requests.Session.send")
+    def test_issue_command_makes_request_to_the_specified_system(self, mock_send):
+        """Issued command should be sent to the specified system if the system argument is specified"""
+
+        def send_request_side_effect(self, **other_args):
+            assert '"system":"TSYS"' in self.body.decode("utf-8").replace(" ", "")
+            mock_response = mock.Mock()
+            mock_response.headers = {"Content-Type": "application/json"}
+            mock_response.status_code = 200
+            mock_response.json.return_value = {}
+            return mock_response
+
+        mock_send.side_effect = send_request_side_effect
+        Console(self.session_details).issue_command("TESTCMD", system="TSYS")
+
+    @mock.patch("requests.Session.send")
     def test_get_response_should_return_messages(self, mock_send_request):
         """Getting z/OS Console response messages on sending a response key"""
         mock_response = mock.Mock()
@@ -64,3 +85,238 @@ class TestConsoleClass(unittest.TestCase):
         mock_send_request.return_value = mock_response
         Console(self.session_details).get_response("console-key")
         mock_send_request.assert_called_once()
+
+    @mock.patch("requests.Session.send")
+    def test_get_log_messages_should_return_operlog_messages_backward(self, mock_send_request):
+        """OPERLOG messages list should be returned with backwards-directed messages by default."""
+        mock_response = mock.Mock()
+        mock_response.headers = {"Content-Type": "application/json"}
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            'items': [
+                {
+                    'cart': '0',
+                    'color': 'green',
+                    'jobName': 'TSTJOB1 ',
+                    'message': ' XYZ1234I Some Test Log Message 1',
+                    'messageId': '12568902641',
+                    'replyId': '0',
+                    'subType': 'NULL',
+                    'system': 'TSTSYS  ',
+                    'time': 'Thu Apr 30 15:37:03 GMT 2026',
+                    'timestamp': 1777563423710,
+                    'type': 'HARDCOPY'
+                },
+                {
+                    'cart': '0',
+                    'color': 'green',
+                    'jobName': 'TSTJOB1 ',
+                    'message': ' XYZ1234I Some Test Log Message 2',
+                    'messageId': '12568902897',
+                    'replyId': '0',
+                    'subType': 'NULL',
+                    'system': 'TSTSYS  ',
+                    'time': 'Thu Apr 30 15:37:03 GMT 2026',
+                    'timestamp': 1777563423710,
+                    'type': 'HARDCOPY'
+                },
+                {
+                    'cart': '-4326849890606516752',
+                    'color': 'green',
+                    'jobName': 'TSTJOB2 ',
+                    'message': ' XYZ1235I Some Other Test Log Message 1',
+                    'messageId': '11362899953',
+                    'replyId': '0',
+                    'subType': 'NULL',
+                    'system': 'TSTSYS  ',
+                    'time': 'Thu Apr 30 15:37:04 GMT 2026',
+                    'timestamp': 1777563424830,
+                    'type': 'HARDCOPY'
+                },
+                {
+                    'cart': '-4326849890606516752',
+                    'color': 'green',
+                    'jobName': '        ',
+                    'message': ' SOME SDSF COMMAND',
+                    'messageId': '11362900209',
+                    'replyId': '0',
+                    'subType': 'NULL',
+                    'system': 'TSTSYS  ',
+                    'time': 'Thu Apr 30 15:37:04 GMT 2026',
+                    'timestamp': 1777563424830,
+                    'type': 'HARDCOPY'
+                },
+                {
+                    'cart': '-4326849890606516752',
+                    'color': 'green',
+                    'jobName': '        ',
+                    'message': ' IEE341I TSTPROG           NOT ACTIVE',
+                    'messageId': '11362900465',
+                    'replyId': '0',
+                    'subType': 'NULL',
+                    'system': 'TSTSYS  ',
+                    'time': 'Thu Apr 30 15:37:04 GMT 2026',
+                    'timestamp': 1777563424830,
+                    'type': 'HARDCOPY'
+                }
+            ],
+            'nextTimestamp': 1777563396310,
+            'source': 'OPERLOG',
+            'timezone': 2,
+            'totalitems': 5
+        }
+        mock_send_request.return_value = mock_response
+        result = Console(self.session_details).get_log_messages(time_range="120s", sys_name="TSTSYS")
+        mock_send_request.assert_called_once()
+        assert isinstance(result, GetLogMessagesResponse)
+        assert len(result.items) == 5
+        assert result.source == "OPERLOG"
+
+    @mock.patch("requests.Session.send")
+    def test_get_log_messages_should_return_syslog_messages_forward(self, mock_send_request):
+        """SYSLOG messages list should be returned with forwards-directed messages by default."""
+        mock_response = mock.Mock()
+        mock_response.headers = {"Content-Type": "application/json"}
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            'items': [
+                {
+                    'cart': '',
+                    'color': '',
+                    'jobName': 'TSTJOB3 ',
+                    'message': 'XYZ1312I Some Test Message 1',
+                    'messageId': '',
+                    'replyId': '',
+                    'subType': 'NULL',
+                    'system': 'TLPR',
+                    'time': 'Thu Apr 30 15:50:06 GMT 2026',
+                    'timestamp': 1777564206900,
+                    'type': 'HARDCOPY'
+                },
+                {
+                    'cart': '',
+                    'color': '',
+                    'jobName': 'TSTJOB3 ',
+                    'message': 'XYZ1312I Some Test Message 2',
+                    'messageId': '',
+                    'replyId': '',
+                    'subType': 'NULL',
+                    'system': 'TLPR',
+                    'time': 'Thu Apr 30 15:50:06 GMT 2026',
+                    'timestamp': 1777564206900,
+                    'type': 'HARDCOPY'
+                },
+                {
+                    'cart': '',
+                    'color': '',
+                    'jobName': 'TSTJOB3 ',
+                    'message': 'XYZ1312I Some Test Message 3',
+                    'messageId': '',
+                    'replyId': '',
+                    'subType': 'NULL',
+                    'system': 'TLPR',
+                    'time': 'Thu Apr 30 15:50:06 GMT 2026',
+                    'timestamp': 1777564206900,
+                    'type': 'HARDCOPY'
+                },
+            ],
+            'nextTimestamp': 0,
+            'source': 'SYSLOG',
+            'timezone': 2,
+            'totalitems': 3
+        }
+        mock_send_request.return_value = mock_response
+        result = Console(self.session_details).get_log_messages(hardcopy="SYSLOG", direction="forward", timestamp=1777564196310)
+        mock_send_request.assert_called_once()
+        assert isinstance(result, GetLogMessagesResponse)
+        assert len(result.items) == 3
+        assert result.source == "SYSLOG"
+        
+    @mock.patch("requests.Session.send")
+    def test_get_log_messages_should_return_by_timestamp_when_time_and_timestamp_provided(self, mock_send_request):
+        """Log messages should be returned with filtering by timestamp when both time and timestamp are speficied."""
+        mock_response = mock.Mock()
+        mock_response.headers = {"Content-Type": "application/json"}
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            'items': [
+                {
+                    'cart': '0',
+                    'color': 'green',
+                    'jobName': 'TSTJOB1 ',
+                    'message': ' XYZ1234I Some Test Log Message 1',
+                    'messageId': '12568902641',
+                    'replyId': '0',
+                    'subType': 'NULL',
+                    'system': 'TSTSYS  ',
+                    'time': 'Thu Apr 30 15:37:03 GMT 2026',
+                    'timestamp': 1777563423710,
+                    'type': 'HARDCOPY'
+                }
+            ],
+            'nextTimestamp': 1777563396310,
+            'source': 'OPERLOG',
+            'timezone': 2,
+            'totalitems': 1
+        }
+        mock_send_request.return_value = mock_response
+        console = Console(self.session_details)
+        with patch.object(console.logger, "warning") as mock_warning:
+            result = console.get_log_messages(direction="forward", time=datetime.now(), timestamp=1777564196310)
+            mock_warning.assert_called_once_with(
+                'Both "time" and "timestamp" query parameters are provided. "time" parameter is ignored'
+            )
+            mock_send_request.assert_called_once()
+            assert isinstance(result, GetLogMessagesResponse)
+            assert len(result.items) == 1
+    
+    @mock.patch("requests.Session.send")
+    def test_get_log_messages_should_return_by_time_with_custom_timezone(self, mock_send_request):
+        """Log messages should be returned from the specified time with the timezone specified."""
+        mock_response = mock.Mock()
+        mock_response.headers = {"Content-Type": "application/json"}
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            'items': [
+                {
+                    'cart': '0',
+                    'color': 'green',
+                    'jobName': 'TSTJOB1 ',
+                    'message': ' XYZ1234I Some Test Log Message 1',
+                    'messageId': '12568902641',
+                    'replyId': '0',
+                    'subType': 'NULL',
+                    'system': 'TSTSYS  ',
+                    'time': 'Thu Apr 30 15:37:03 GMT 2026',
+                    'timestamp': 1777563423710,
+                    'type': 'HARDCOPY'
+                }
+            ],
+            'nextTimestamp': 1777563396310,
+            'source': 'OPERLOG',
+            'timezone': 2,
+            'totalitems': 1
+        }
+        mock_send_request.return_value = mock_response
+        console = Console(self.session_details)
+        with patch.object(console.logger, "warning") as mock_warning:
+            test_datetime = datetime.now(tz=timezone(timedelta(hours=3)))
+            result = console.get_log_messages(direction="forward", time=test_datetime)
+            mock_warning.assert_called_once_with(
+                f'"time" query parameter is not in UTC timezone ({test_datetime.tzinfo}). Conversion to UTC will occur'
+            )
+            mock_send_request.assert_called_once()
+            assert isinstance(result, GetLogMessagesResponse)
+            assert len(result.items) == 1
+
+    @mock.patch("requests.Session.send")
+    def test_get_log_messages_produces_error(self, mock_send_request):
+        """An error with return code and reason should be produced."""
+        mock_response = mock.Mock()
+        mock_response.headers = {"Content-Type": "application/json"}
+        mock_response.status_code = 400
+        mock_response.json.return_value = {'returnCode': 1, 'reasonCode': 2, 'reason': 'Some Test Error'}
+        mock_send_request.return_value = mock_response
+        result = Console(self.session_details).get_log_messages()
+        mock_send_request.assert_called_once()
+        assert isinstance(result, UnsuccessfulGetLogMessagesResponse)

--- a/tests/unit/test_zos_jobs.py
+++ b/tests/unit/test_zos_jobs.py
@@ -1,8 +1,10 @@
 """Unit tests for the Zowe Python SDK z/OS Jobs package."""
 
+from datetime import datetime
 from unittest import TestCase, mock
 
 from zowe.zos_jobs_for_zowe_sdk import Jobs
+from zowe.zos_jobs_for_zowe_sdk.response.jobs import JobResponse
 
 
 class TestJobsClass(TestCase):
@@ -78,6 +80,71 @@ class TestJobsClass(TestCase):
 
         Jobs(self.test_profile).release_job("TESTJOB2", "JOB00084")
         mock_send_request.assert_called_once()
+
+    @mock.patch("requests.Session.send")
+    def test_list_jobs(self, mock_send_request):
+        """Test list jobs sends request"""
+        mock_response = mock.Mock()
+        mock_response.headers = {"Content-Type": "application/json"}
+        mock_response.status_code = 200
+        mock_response.json.return_value = [
+            {
+                "class": "T",
+                "files-url": "https://tsthost:443/zosmf/restjobs/jobs/TESTJI1XCFPLX01E1BE8B01.......%3A/files",
+                "job-correlator": "TESTJI1XCFPLX01E1BE8B01.......:",
+                "jobid": "TESTJI1",
+                "jobname": "TESTJN1",
+                "owner": "TSTUSR",
+                "phase": 0,
+                "phasename": "Job is on the hard copy queue",
+                "retcode": "CC 0000",
+                "status": "OUTPUT",
+                "subsystem": "JES2",
+                "type": "JOB",
+                "url": "https://tsthost:443/zosmf/restjobs/jobs/TESTJI1XCFPLX01E1BE8B01.......%3A"
+            }
+        ]
+        mock_send_request.return_value = mock_response
+        result = Jobs(self.test_profile).list_jobs()
+        assert len(result) == 1
+        assert isinstance(result[0], JobResponse)
+        self.assertEqual(mock_send_request.call_count, 1)
+
+    @mock.patch("requests.Session.send")
+    def test_list_jobs_ext(self, mock_send_request):
+        """Test list jobs sends request with exec-data fetched"""
+        mock_response = mock.Mock()
+        mock_response.headers = {"Content-Type": "application/json"}
+        mock_response.status_code = 200
+        mock_response.json.return_value = [
+            {
+                "class": "T",
+                "files-url": "https://tsthost:443/zosmf/restjobs/jobs/TESTJI2XCFPLX01E1BE8B01.......%3A/files",
+                "job-correlator": "TESTJI2XCFPLX01E1BE8B01.......:",
+                "jobid": "TESTJI2",
+                "jobname": "TSTPREF",
+                "owner": "TSTOWR",
+                "phase": 0,
+                "phasename": "Job is actively executing",
+                "retcode": "CC 0000",
+                "status": "ACTIVE",
+                "subsystem": "JES2",
+                "type": "JOB",
+                "url": "https://tsthost:443/zosmf/restjobs/jobs/TESTJI2XCFPLX01E1BE8B01.......%3A",
+                "exec-ended": "2025-11-05T13:52:21.920Z",
+                "exec-member": "SMFT",
+                "exec-started": "2025-11-05T13:52:21.310Z",
+                "exec-submitted": "2025-11-05T13:52:21.290Z",
+                "exec-system": "SYST"
+            }
+        ]
+        mock_send_request.return_value = mock_response
+        result = Jobs(self.test_profile).list_jobs("TSTOWR", "TSTPREF", 100, "SOME-USER-COR", True, 'ACTIVE')
+        assert len(result) == 1
+        assert isinstance(result[0], JobResponse)
+        assert result[0].exec_system is not None
+        assert isinstance(result[0].exec_submitted, datetime)
+        self.assertEqual(mock_send_request.call_count, 1)
 
     @mock.patch("requests.Session.send")
     def test_change_job_class(self, mock_send_request):


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Added get_log_messages console REST API function, added exec-data and status query parameters to list_jobs, corrected members parsing, list_members enhancement
<!-- **Does this close any currently open issues?**
If this PR closes an issue, please uncomment the line below and include the issue number.
Fixes #(issue_number) -->

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
Use `Console.get_log_messages` to get messages from SYSLOG/OPERLOG.
Use `fetch_exec_data=True` flag with `Jobs.list_jobs` to fetch `exec-data` with the list of jobs.
User `status='ACTIVE'` flag with `Jobs.list_jobs` to fetch jobs that are active at the moment.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->