### PR TITLE
fix: remove hardcoded 30-second timeout to support large file transfers (closes #392)

### DIFF
--- a/src/core/zowe/core_for_zowe_sdk/sdk_api.py
+++ b/src/core/zowe/core_for_zowe_sdk/sdk_api.py
@@ -59,7 +59,7 @@ class SdkApi:
         }
         self.__session_arguments: dict[str, Any] = {
             "verify": self.session.reject_unauthorized,
-            "timeout": 30,
+            "timeout": None,
         }
         self.request_handler = RequestHandler(self.__session_arguments, logger_name=logger_name)
 


### PR DESCRIPTION
## What
Hardcoded timeout of 30 seconds in `sdk_api.py` causes `requests.exceptions.ConnectionError: ('Connection aborted.', TimeoutError('The write operation timed out'))` when uploading/downloading large files (e.g., SMP/E packages) that take longer than 30 seconds.

## Fix
Changed the timeout from 30 to `None`, which disables the timeout for the requests Session. This allows large file operations to complete without premature termination.

Closes `#392`