### PR TITLE
fix: increase default request timeout to avoid failures on large file transfers (closes #392)

### DIFF
--- a/src/core/zowe/core_for_zowe_sdk/sdk_api.py
+++ b/src/core/zowe/core_for_zowe_sdk/sdk_api.py
@@ -59,7 +59,7 @@ class SdkApi:
         }
         self.__session_arguments: dict[str, Any] = {
             "verify": self.session.reject_unauthorized,
-            "timeout": 30,
+            "timeout": 600,
         }
         self.request_handler = RequestHandler(self.__session_arguments, logger_name=logger_name)
 


### PR DESCRIPTION
## What
The hardcoded 30-second timeout in SdkApi causes connection timeouts when transferring large files (e.g., SMP/E packages) that take longer than 30 seconds.

## Fix
Increased the default timeout from 30 seconds to 600 seconds (10 minutes) to accommodate large file uploads and downloads. This change is minimal and does not break existing API contracts, while allowing long-running operations to complete successfully.

Closes #392