### PR TITLE
fix: increase default session timeout to prevent large file transfer failures (closes #392)

### DIFF
--- a/src/core/zowe/core_for_zowe_sdk/sdk_api.py
+++ b/src/core/zowe/core_for_zowe_sdk/sdk_api.py
@@ -59,7 +59,7 @@ class SdkApi:
         }
         self.__session_arguments: dict[str, Any] = {
             "verify": self.session.reject_unauthorized,
-            "timeout": 30,
+            "timeout": 300,
         }
         self.request_handler = RequestHandler(self.__session_arguments, logger_name=logger_name)
 


### PR DESCRIPTION
## What
The session timeout was hardcoded to 30 seconds, causing large file uploads/downloads (e.g., SMP/E packages) to fail with a `ConnectionError: ('Connection aborted.', TimeoutError('The write operation timed out'))` after approximately 30 seconds.

## Fix
Increased the default timeout from 30 seconds to 300 seconds (5 minutes) to accommodate large file transfers that require longer to complete. This value can still be overridden by the user if needed.

Closes #392