### PR TITLE
Pin `secrets_core` to v8.35.2

### DIFF
--- a/.github/workflows/secrets-sdk.yml
+++ b/.github/workflows/secrets-sdk.yml
@@ -42,7 +42,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist
+          args: --release --locked --out dist
           sccache: "true"
           manylinux: auto
           docker-options: -e PKG_CONFIG_SYSROOT_DIR -e PKG_CONFIG_PATH
@@ -80,7 +80,7 @@ jobs:
         with:
           maturin-version: v1.9.4  # https://github.com/PyO3/maturin/issues/2767
           target: ${{ matrix.target }}
-          args: --release --out dist
+          args: --release --locked --out dist
           sccache: "true"
           working-directory: src/secrets
       - name: Upload wheels
@@ -104,7 +104,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist
+          args: --release --locked --out dist
           sccache: "true"
           working-directory: src/secrets
       - name: Upload wheels

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to the Zowe Client Python SDK will be documented in this fil
 ### Bug Fixes
 
 - Updated the `pyo3` dependency of the Secrets SDK for technical currency. [#399](https://github.com/zowe/zowe-client-python-sdk/pull/399)
-- Pinned the `secrets_core` dependency of the Secrets SDK to a fixed commit instead of the `master` branch so wheel builds are reproducible, and updated it to Zowe CLI 8.35.1. [#407](https://github.com/zowe/zowe-client-python-sdk/pull/407)
+- Pinned the `secrets_core` dependency of the Secrets SDK to a fixed commit instead of the `master` branch so wheel builds are reproducible.
 
 ## `1.0.0-dev26`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the Zowe Client Python SDK will be documented in this fil
 ### Bug Fixes
 
 - Updated the `pyo3` dependency of the Secrets SDK for technical currency. [#399](https://github.com/zowe/zowe-client-python-sdk/pull/399)
+- Pinned the `secrets_core` dependency of the Secrets SDK to a fixed commit instead of the `master` branch so wheel builds are reproducible.
 
 ## `1.0.0-dev26`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to the Zowe Client Python SDK will be documented in this fil
 ### Bug Fixes
 
 - Updated the `pyo3` dependency of the Secrets SDK for technical currency. [#399](https://github.com/zowe/zowe-client-python-sdk/pull/399)
-- Pinned the `secrets_core` dependency of the Secrets SDK to a fixed commit instead of the `master` branch so wheel builds are reproducible.
+- Pinned the `secrets_core` dependency of the Secrets SDK to a fixed commit instead of the `master` branch so wheel builds are reproducible. [#407](https://github.com/zowe/zowe-client-python-sdk/pull/407)
 
 ## `1.0.0-dev26`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to the Zowe Client Python SDK will be documented in this fil
 ### Bug Fixes
 
 - Updated the `pyo3` dependency of the Secrets SDK for technical currency. [#399](https://github.com/zowe/zowe-client-python-sdk/pull/399)
-- Pinned the `secrets_core` dependency of the Secrets SDK to a fixed commit instead of the `master` branch so wheel builds are reproducible. [#407](https://github.com/zowe/zowe-client-python-sdk/pull/407)
+- Pinned the `secrets_core` dependency of the Secrets SDK to a fixed commit instead of the `master` branch so wheel builds are reproducible, and updated it to Zowe CLI 8.35.1. [#407](https://github.com/zowe/zowe-client-python-sdk/pull/407)
 
 ## `1.0.0-dev26`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to the Zowe Client Python SDK will be documented in this fil
 ### Bug Fixes
 
 - Updated the `pyo3` dependency of the Secrets SDK for technical currency. [#399](https://github.com/zowe/zowe-client-python-sdk/pull/399)
-- Pinned the `secrets_core` dependency of the Secrets SDK to a fixed commit instead of the `master` branch so wheel builds are reproducible.
+- Pinned the `secrets_core` dependency of the Secrets SDK to a fixed commit instead of the `master` branch so wheel builds are reproducible, and updated it to Zowe CLI 8.35.1. [#407](https://github.com/zowe/zowe-client-python-sdk/pull/407)
 
 ## `1.0.0-dev26`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to the Zowe Client Python SDK will be documented in this fil
 ### Bug Fixes
 
 - Updated the `pyo3` dependency of the Secrets SDK for technical currency. [#399](https://github.com/zowe/zowe-client-python-sdk/pull/399)
-- Pinned the `secrets_core` dependency of the Secrets SDK to a fixed commit instead of the `master` branch so wheel builds are reproducible, and updated it to Zowe CLI 8.35.1. [#407](https://github.com/zowe/zowe-client-python-sdk/pull/407)
+- Pinned the `secrets_core` dependency of the Secrets SDK to the Zowe CLI 8.35.1 release tag instead of the `master` branch so wheel builds are reproducible. [#407](https://github.com/zowe/zowe-client-python-sdk/pull/407)
 
 ## `1.0.0-dev26`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to the Zowe Client Python SDK will be documented in this fil
 
 - Fixed `Jobs.get_job_output_as_files` writing to a directory it never created, and made job output paths stay within the target directory. [#403](https://github.com/zowe/zowe-client-python-sdk/pull/403)
 - Updated the `pyo3` dependency of the Secrets SDK for technical currency. [#399](https://github.com/zowe/zowe-client-python-sdk/pull/399)
-- Pinned the `secrets_core` dependency of the Secrets SDK to the Zowe CLI 8.35.1 release tag instead of the `master` branch so wheel builds are reproducible. [#407](https://github.com/zowe/zowe-client-python-sdk/pull/407)
+- Updated the `secrets_core` dependency of the Secrets SDK to Zowe CLI 8.35.1 and pinned it to a commit for reproducible builds. [#407](https://github.com/zowe/zowe-client-python-sdk/pull/407)
 
 ## `1.0.0-dev26`
 

--- a/src/secrets/Cargo.lock
+++ b/src/secrets/Cargo.lock
@@ -421,7 +421,7 @@ dependencies = [
 [[package]]
 name = "secrets_core"
 version = "0.1.0"
-source = "git+https://github.com/zowe/zowe-cli.git?branch=master#4d2539a49c9469e9293f5fe562f74ec6e874a085"
+source = "git+https://github.com/zowe/zowe-cli.git?rev=4d2539a49c9469e9293f5fe562f74ec6e874a085#4d2539a49c9469e9293f5fe562f74ec6e874a085"
 dependencies = [
  "cfg-if",
  "core-foundation",

--- a/src/secrets/Cargo.lock
+++ b/src/secrets/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,9 +16,21 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "cfg-expr"
@@ -51,6 +69,15 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "fmutex"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01e84c17070603126a7b0cd07d0ecc8e8cca4d15b67934ac2740286a84f3086c"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "futures-channel"
@@ -116,6 +143,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+]
+
+[[package]]
 name = "gio"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,7 +191,7 @@ version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c316afb01ce8067c5eaab1fc4f2cd47dc21ce7b6296358605e2ffab23ccbd19"
 dependencies = [
- "bitflags",
+ "bitflags 2.4.1",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -234,6 +272,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "keyring"
 version = "1.0.0-dev12"
 dependencies = [
@@ -243,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.149"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libsecret"
@@ -419,20 +468,69 @@ dependencies = [
 ]
 
 [[package]]
-name = "secrets_core"
-version = "0.1.0"
-source = "git+https://github.com/zowe/zowe-cli.git?rev=4d2539a49c9469e9293f5fe562f74ec6e874a085#4d2539a49c9469e9293f5fe562f74ec6e874a085"
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "secrets_core"
+version = "0.1.1"
+source = "git+https://github.com/zowe/zowe-cli.git?rev=b2db1840f140b72a3352df56f0802ea4ce213dc5#b2db1840f140b72a3352df56f0802ea4ce213dc5"
+dependencies = [
+ "adler2",
  "cfg-if",
  "core-foundation",
  "core-foundation-sys",
+ "fmutex",
  "gio",
  "glib",
  "glib-sys",
  "libsecret",
  "libsecret-sys",
+ "schannel",
+ "security-framework",
  "thiserror",
- "windows-sys",
+ "uuid",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -597,6 +695,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
+name = "uuid"
+version = "1.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+dependencies = [
+ "getrandom",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "version-compare"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,6 +716,51 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "winapi"
@@ -631,12 +785,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/src/secrets/Cargo.lock
+++ b/src/secrets/Cargo.lock
@@ -491,7 +491,7 @@ dependencies = [
 [[package]]
 name = "secrets_core"
 version = "0.1.1"
-source = "git+https://github.com/zowe/zowe-cli.git?rev=b2db1840f140b72a3352df56f0802ea4ce213dc5#b2db1840f140b72a3352df56f0802ea4ce213dc5"
+source = "git+https://github.com/zowe/zowe-cli.git?tag=v8.35.1#b2db1840f140b72a3352df56f0802ea4ce213dc5"
 dependencies = [
  "adler2",
  "cfg-if",

--- a/src/secrets/Cargo.lock
+++ b/src/secrets/Cargo.lock
@@ -3,12 +3,6 @@
 version = 4
 
 [[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16,21 +10,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
-
-[[package]]
-name = "bumpalo"
-version = "3.20.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "cfg-expr"
@@ -69,15 +51,6 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
-
-[[package]]
-name = "fmutex"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01e84c17070603126a7b0cd07d0ecc8e8cca4d15b67934ac2740286a84f3086c"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "futures-channel"
@@ -143,17 +116,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi",
-]
-
-[[package]]
 name = "gio"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,7 +153,7 @@ version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c316afb01ce8067c5eaab1fc4f2cd47dc21ce7b6296358605e2ffab23ccbd19"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -272,17 +234,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "js-sys"
-version = "0.3.103"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
-dependencies = [
- "cfg-if",
- "futures-util",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "keyring"
 version = "1.0.0-dev12"
 dependencies = [
@@ -292,9 +243,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.189"
+version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
 name = "libsecret"
@@ -468,69 +419,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "r-efi"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-
-[[package]]
-name = "rustversion"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
-
-[[package]]
-name = "schannel"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "secrets_core"
-version = "0.1.1"
-source = "git+https://github.com/zowe/zowe-cli.git?rev=b2db1840f140b72a3352df56f0802ea4ce213dc5#b2db1840f140b72a3352df56f0802ea4ce213dc5"
+version = "0.1.0"
+source = "git+https://github.com/zowe/zowe-cli.git?rev=4d2539a49c9469e9293f5fe562f74ec6e874a085#4d2539a49c9469e9293f5fe562f74ec6e874a085"
 dependencies = [
- "adler2",
  "cfg-if",
  "core-foundation",
  "core-foundation-sys",
- "fmutex",
  "gio",
  "glib",
  "glib-sys",
  "libsecret",
  "libsecret-sys",
- "schannel",
- "security-framework",
  "thiserror",
- "uuid",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
-dependencies = [
- "core-foundation-sys",
- "libc",
+ "windows-sys",
 ]
 
 [[package]]
@@ -695,17 +597,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
-name = "uuid"
-version = "1.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
-dependencies = [
- "getrandom",
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "version-compare"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -716,51 +607,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "wasm-bindgen"
-version = "0.2.126"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
-dependencies = [
- "cfg-if",
- "once_cell",
- "rustversion",
- "wasm-bindgen-macro",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.126"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.126"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
-dependencies = [
- "bumpalo",
- "proc-macro2",
- "quote",
- "syn 2.0.79",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.126"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
-dependencies = [
- "unicode-ident",
-]
 
 [[package]]
 name = "winapi"
@@ -785,27 +631,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows-link"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
-dependencies = [
- "windows-link",
 ]
 
 [[package]]

--- a/src/secrets/Cargo.lock
+++ b/src/secrets/Cargo.lock
@@ -491,7 +491,7 @@ dependencies = [
 [[package]]
 name = "secrets_core"
 version = "0.1.1"
-source = "git+https://github.com/zowe/zowe-cli.git?rev=b2db1840f140b72a3352df56f0802ea4ce213dc5#b2db1840f140b72a3352df56f0802ea4ce213dc5"
+source = "git+https://github.com/zowe/zowe-cli.git?rev=fc8b31ce0de3c7c8a9a371dd43f3daf6a133f002#fc8b31ce0de3c7c8a9a371dd43f3daf6a133f002"
 dependencies = [
  "adler2",
  "cfg-if",

--- a/src/secrets/Cargo.lock
+++ b/src/secrets/Cargo.lock
@@ -491,7 +491,7 @@ dependencies = [
 [[package]]
 name = "secrets_core"
 version = "0.1.1"
-source = "git+https://github.com/zowe/zowe-cli.git?tag=v8.35.1#b2db1840f140b72a3352df56f0802ea4ce213dc5"
+source = "git+https://github.com/zowe/zowe-cli.git?rev=b2db1840f140b72a3352df56f0802ea4ce213dc5#b2db1840f140b72a3352df56f0802ea4ce213dc5"
 dependencies = [
  "adler2",
  "cfg-if",

--- a/src/secrets/Cargo.toml
+++ b/src/secrets/Cargo.toml
@@ -12,6 +12,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.29.0", features = ["abi3-py310", "generate-import-lib"] }
-# Pinned to a release tag so builds are reproducible
-# Cargo.lock records the exact commit this resolves to
-secrets_core = { git = "https://github.com/zowe/zowe-cli.git", tag = "v8.35.1" }
+# Pinned to a commit so builds are reproducible
+secrets_core = { git = "https://github.com/zowe/zowe-cli.git", rev = "b2db1840f140b72a3352df56f0802ea4ce213dc5" } # v8.35.1

--- a/src/secrets/Cargo.toml
+++ b/src/secrets/Cargo.toml
@@ -13,4 +13,4 @@ crate-type = ["cdylib"]
 [dependencies]
 pyo3 = { version = "0.29.0", features = ["abi3-py310", "generate-import-lib"] }
 # Pinned to an immutable commit so builds are reproducible
-secrets_core = { git = "https://github.com/zowe/zowe-cli.git", rev = "b2db1840f140b72a3352df56f0802ea4ce213dc5" } # 8.35.1
+secrets_core = { git = "https://github.com/zowe/zowe-cli.git", rev = "4d2539a49c9469e9293f5fe562f74ec6e874a085" }

--- a/src/secrets/Cargo.toml
+++ b/src/secrets/Cargo.toml
@@ -13,4 +13,4 @@ crate-type = ["cdylib"]
 [dependencies]
 pyo3 = { version = "0.29.0", features = ["abi3-py310", "generate-import-lib"] }
 # Pinned to an immutable commit so builds are reproducible
-secrets_core = { git = "https://github.com/zowe/zowe-cli.git", rev = "4d2539a49c9469e9293f5fe562f74ec6e874a085" }
+secrets_core = { git = "https://github.com/zowe/zowe-cli.git", rev = "b2db1840f140b72a3352df56f0802ea4ce213dc5" } # 8.35.1

--- a/src/secrets/Cargo.toml
+++ b/src/secrets/Cargo.toml
@@ -12,4 +12,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.29.0", features = ["abi3-py310", "generate-import-lib"] }
-secrets_core = { git = "https://github.com/zowe/zowe-cli.git", branch = "master" }
+# Pinned to an immutable commit so builds are reproducible
+secrets_core = { git = "https://github.com/zowe/zowe-cli.git", rev = "4d2539a49c9469e9293f5fe562f74ec6e874a085" }

--- a/src/secrets/Cargo.toml
+++ b/src/secrets/Cargo.toml
@@ -12,5 +12,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.29.0", features = ["abi3-py310", "generate-import-lib"] }
-# Pinned to an immutable commit so builds are reproducible
-secrets_core = { git = "https://github.com/zowe/zowe-cli.git", rev = "b2db1840f140b72a3352df56f0802ea4ce213dc5" } # 8.35.1
+# Pinned to a release tag so builds are reproducible
+# Cargo.lock records the exact commit this resolves to
+secrets_core = { git = "https://github.com/zowe/zowe-cli.git", tag = "v8.35.1" }

--- a/src/secrets/Cargo.toml
+++ b/src/secrets/Cargo.toml
@@ -13,4 +13,4 @@ crate-type = ["cdylib"]
 [dependencies]
 pyo3 = { version = "0.29.0", features = ["abi3-py310", "generate-import-lib"] }
 # Pinned to a commit so builds are reproducible
-secrets_core = { git = "https://github.com/zowe/zowe-cli.git", rev = "b2db1840f140b72a3352df56f0802ea4ce213dc5" } # v8.35.1
+secrets_core = { git = "https://github.com/zowe/zowe-cli.git", rev = "fc8b31ce0de3c7c8a9a371dd43f3daf6a133f002" } # v8.35.2


### PR DESCRIPTION
**What It Does**
Pins the `secrets_core` dependency of the Secrets SDK to the v8.35.1 release tag and saves the commit SHA to cargo.lock. [Dependabot can review if the tag is old and spin up a PR to update to the newest tag and commit](https://github.com/zowe/zowe-client-python-sdk/pull/410) #410 
**How to Test**

**Review Checklist**
I certify that I have:
- [X] updated the changelog
- [X] manually tested my changes
- [ ] added/updated automated unit/integration tests
- [ ] created/ran system tests (provide build number if applicable)
- [X] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->