### PR TITLE
Fix secure credential loading for nested team-config profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to the Zowe Client Python SDK will be documented in this fil
 
 ### Bug Fixes
 
+- Fixed secure `user`/`password` properties not being loaded for team-config profiles nested more than one level deep which caused 401 errors. [#411](https://github.com/zowe/zowe-client-python-sdk/pull/411)
 - Redacted request headers and restricted log directory/file to owner-only access. [#404](https://github.com/zowe/zowe-client-python-sdk/pull/404)
 - Fixed `Jobs.get_job_output_as_files` writing to a directory it never created, and made job output paths stay within the target directory. [#403](https://github.com/zowe/zowe-client-python-sdk/pull/403)
 - Updated the `pyo3` dependency of the Secrets SDK for technical currency. [#399](https://github.com/zowe/zowe-client-python-sdk/pull/399)

--- a/src/core/zowe/core_for_zowe_sdk/config_file.py
+++ b/src/core/zowe/core_for_zowe_sdk/config_file.py
@@ -383,7 +383,7 @@ class ConfigFile:
         for k, v in profiles.items():
             if not isinstance(v, dict):  # Ensure v is a dictionary
                 if not self.__suppress_config_file_warnings:
-                    self.__logger.warning("Invalid profile passed when schame validation is off")
+                    self.__logger.warning("Invalid profile passed when schema validation is off")
                 continue  # Skip invalid entries
 
             if segments[0] == k:
@@ -441,24 +441,14 @@ class ConfigFile:
     def __load_secure_properties(self) -> None:
         """Inject secure properties that have been loaded from the vault into the profiles object."""
         secure_props = CredentialManager.secure_props.get(self.filepath or "", {})
+        if self.profiles is None:
+            return
         for key, value in secure_props.items():
             segments = [name for i, name in enumerate(key.split(".")) if i % 2 == 1]
-            profiles_obj = self.profiles
             property_name = segments.pop()
-            for i, profile_name in enumerate(segments):
-                if profiles_obj is None or not isinstance(profiles_obj, dict):
-                    break
-                if profile_name in profiles_obj:
-                    profiles_obj = profiles_obj[profile_name]
-                    if not isinstance(profiles_obj, dict):
-                        break
-                    if i == len(segments) - 1:
-                        profiles_obj.setdefault("properties", {})
-                        profiles_obj["properties"][property_name] = value
-                    else:
-                        profiles_obj = profiles_obj.get("profiles", {})
-                else:
-                    break
+            profile = self.find_profile(".".join(segments), self.profiles)
+            if profile is not None:
+                profile.setdefault("properties", {})[property_name] = value
 
     def __extract_secure_properties(
         self, profiles_obj: dict[str, Any], json_path: Optional[str] = "profiles"

--- a/src/core/zowe/core_for_zowe_sdk/config_file.py
+++ b/src/core/zowe/core_for_zowe_sdk/config_file.py
@@ -441,8 +441,6 @@ class ConfigFile:
     def __load_secure_properties(self) -> None:
         """Inject secure properties that have been loaded from the vault into the profiles object."""
         secure_props = CredentialManager.secure_props.get(self.filepath or "", {})
-        if self.profiles is None:
-            return
         for key, value in secure_props.items():
             segments = [name for i, name in enumerate(key.split(".")) if i % 2 == 1]
             property_name = segments.pop()

--- a/src/core/zowe/core_for_zowe_sdk/config_file.py
+++ b/src/core/zowe/core_for_zowe_sdk/config_file.py
@@ -455,6 +455,8 @@ class ConfigFile:
                     if i == len(segments) - 1:
                         profiles_obj.setdefault("properties", {})
                         profiles_obj["properties"][property_name] = value
+                    else:
+                        profiles_obj = profiles_obj.get("profiles", {})
                 else:
                     break
 

--- a/tests/unit/core/test_profile_manager.py
+++ b/tests/unit/core/test_profile_manager.py
@@ -183,6 +183,58 @@ class TestZosmfProfileManager(TestCase):
         self.assertEqual(props, expected_props)
 
     @mock.patch("zowe.secrets_for_zowe_sdk.keyring.get_password", side_effect=keyring_get_password)
+    def test_nested_profile_with_secure_properties_on_child(self, get_pass_func):
+        """
+        Test that secure properties declared on a child profile nested under a
+        parent (e.g. mainframe.zosmf) are correctly loaded from the vault.
+
+        Regression test: __load_secure_properties previously looked for the
+        child profile name as a direct key of the parent profile dict, but
+        nested profiles actually live one level deeper under the parent's
+        own "profiles" key, so secure user/password values were silently
+        never injected for any profile nested more than one level deep.
+        """
+        custom_file_path = os.path.join(self.custom_dir, self.custom_filename)
+        config_contents = {
+            "$schema": "./zowe.schema.json",
+            "profiles": {
+                "mainframe": {
+                    "properties": {"host": "example.com"},
+                    "profiles": {
+                        "zosmf": {
+                            "type": "zosmf",
+                            "properties": {"port": 1443},
+                            "secure": ["user", "password"],
+                        }
+                    },
+                }
+            },
+            "defaults": {"zosmf": "mainframe.zosmf"},
+        }
+        with open(custom_file_path, "w") as f:
+            json.dump(config_contents, f)
+
+        self.setUpCreds(
+            custom_file_path,
+            {
+                "profiles.mainframe.profiles.zosmf.properties.user": "admin",
+                "profiles.mainframe.profiles.zosmf.properties.password": "secret",
+            },
+        )
+
+        prof_manager = ProfileManager(appname=self.custom_appname)
+        prof_manager.config_dir = self.custom_dir
+        props: dict = prof_manager.load(profile_name="mainframe.zosmf", validate_schema=False)
+
+        expected_props = {
+            "host": "example.com",
+            "port": 1443,
+            "user": "admin",
+            "password": "secret",
+        }
+        self.assertEqual(props, expected_props)
+
+    @mock.patch("zowe.secrets_for_zowe_sdk.keyring.get_password", side_effect=keyring_get_password)
     def test_profile_loading_with_user_overridden_properties(self, get_pass_func):
         """
         Test overriding of properties from user config,


### PR DESCRIPTION
**What It Does**
When testing https://github.com/zowe/zowe-client-python-sdk/pull/408 i found that the way i structured my config was returning 401s
ie: 
```
mainframe ->
  -> properties
       -> host
  -> profiles
       -> zosmf ->
            -> properties
                 -> port
            -> secure
                 -> user
                 -> password
```   
                 
found that `__load_secure_properties` looked for zosmf as a direct key of the mainframe profile but zosmf actually lives one level deeper, under the profiles key.

the fix to config_file.py handles however many levels a config nests 

`test_custom_file_and_custom_profile_loading_with_nested_profil`e user/password values came from a plaintext override in `nested.zowe.config.user.json`, not from the vault. So apparently no test ever exercised `__load_secure_properties` for a profile nested more than one level deep with secure fields on the child! Added a new test (`test_nested_profile_with_secure_properties_on_child`) that pulls creds from the mocked vault
**How to Test**
change your config to match this level of nesting when testing. verify that you get 401s on main and you can run system tests on this branch :)
**Review Checklist**
I certify that I have:
- [x] updated the changelog
- [x] manually tested my changes
- [x] added/updated automated unit/integration tests
- [x] created/ran system tests (provide build number if applicable)
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->